### PR TITLE
Speed up reading large text parts

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -274,6 +274,18 @@ function write (chunk) {
         }
       continue;
       case S.TEXT:
+        if (parser.sawRoot && !parser.closedRoot) {
+          var starti = i-1;
+          while (c && c!=="<" && c!=="&") {
+            c = chunk.charAt(i++);
+            parser.position ++;
+            if (c === "\n") {
+              parser.line ++;
+              parser.column = 0;
+            } else parser.column ++;
+          }
+          parser.textNode += chunk.substring(starti, i-1);
+        }
         if (c === "<") parser.state = S.OPEN_WAKA;
         else {
           if (not(whitespace, c) && (!parser.sawRoot || parser.closedRoot))


### PR DESCRIPTION
Avoid doing a big amount of one-character-string-concatenations.
Gives me a speed increase of 169% for reading two minutes of
german wikipedia dump.
