### PR TITLE
Fix to make the parser commonjs independend

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1,4 +1,4 @@
-
+var exports = exports || {};
 var sax = exports;
 sax.parser = function (strict, opt) { return new SAXParser(strict, opt) };
 sax.SAXParser = SAXParser;


### PR DESCRIPTION
A quick fix to avoid an error when loading the file in a browser ("exports is not defined").
