### PR TITLE
Fixed bug with position in chunked text-nodes.

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -278,11 +278,13 @@ function write (chunk) {
           var starti = i-1;
           while (c && c!=="<" && c!=="&") {
             c = chunk.charAt(i++);
-            parser.position ++;
-            if (c === "\n") {
-              parser.line ++;
-              parser.column = 0;
-            } else parser.column ++;
+            if (c) {
+              parser.position ++;
+              if (c === "\n") {
+                parser.line ++;
+                parser.column = 0;
+              } else parser.column ++;
+            }
           }
           parser.textNode += chunk.substring(starti, i-1);
         }

--- a/test/parser-position.js
+++ b/test/parser-position.js
@@ -1,0 +1,27 @@
+var sax = require("../lib/sax"),
+    assert = require("assert")
+
+function testPosition(chunks, expectedEvents) {
+  var parser = sax.parser();
+  expectedEvents.forEach(function(expectation) {
+    parser['on' + expectation[0]] = function() {
+      assert.equal(parser.position, expectation[1]);
+    }
+  });
+  chunks.forEach(function(chunk) {
+    parser.write(chunk);
+  });
+};
+
+testPosition(['<div>abcdefgh</div>'],
+             [ ['opentag', 5]
+             , ['text', 19]
+             , ['closetag', 19]
+             ]);
+
+testPosition(['<div>abcde','fgh</div>'],
+             [ ['opentag', 5]
+             , ['text', 19]
+             , ['closetag', 19]
+             ]);
+


### PR DESCRIPTION
Commit 53ea8d77af59a8bd6e30 (Speed up reading large text parts) introduced a bug with the parser.position when text-nodes are chunked. This patch should fix this.
