### PR TITLE
Support for getting the position of the start of the opentag/closetag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ At all times, the parser object will have the following members:
 `line`, `column`, `position` - Indications of the position in the XML document where
 the parser currently is looking.
 
+`startTagPosition` - Indicates the position where the current tag starts.
+
 `closed` - Boolean indicating whether or not the parser can be written to.  If it's
 `true`, then wait for the `ready` event to write again.
 

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -304,9 +304,11 @@ function write (chunk) {
         } else if (is(whitespace, c)) {
           // wait for it...
         } else if (is(nameStart,c)) {
+          parser.startTagPosition = parser.position - 1;
           parser.state = S.OPEN_TAG;
           parser.tagName = c;
         } else if (c === "/") {
+          parser.startTagPosition = parser.position - 1;
           parser.state = S.CLOSE_TAG;
           parser.tagName = "";
         } else if (c === "?") {

--- a/test/parser-position.js
+++ b/test/parser-position.js
@@ -5,7 +5,9 @@ function testPosition(chunks, expectedEvents) {
   var parser = sax.parser();
   expectedEvents.forEach(function(expectation) {
     parser['on' + expectation[0]] = function() {
-      assert.equal(parser.position, expectation[1]);
+      for (var prop in expectation[1]) {
+        assert.equal(parser[prop], expectation[1][prop]);
+      }
     }
   });
   chunks.forEach(function(chunk) {
@@ -14,14 +16,13 @@ function testPosition(chunks, expectedEvents) {
 };
 
 testPosition(['<div>abcdefgh</div>'],
-             [ ['opentag', 5]
-             , ['text', 19]
-             , ['closetag', 19]
+             [ ['opentag',  { position:  5, startTagPosition:  1 }]
+             , ['text',     { position: 19, startTagPosition: 14 }]
+             , ['closetag', { position: 19, startTagPosition: 14 }]
              ]);
 
 testPosition(['<div>abcde','fgh</div>'],
-             [ ['opentag', 5]
-             , ['text', 19]
-             , ['closetag', 19]
+             [ ['opentag',  { position:  5, startTagPosition:  1 }]
+             , ['text',     { position: 19, startTagPosition: 14 }]
+             , ['closetag', { position: 19, startTagPosition: 14 }]
              ]);
-


### PR DESCRIPTION
We are using sax-js to pull out one or more parts of a document. We listen to the opentag and closetag events to find the start and end position in the stream, however parser.position only gives us the position at the end of the opentag or closetag (>). We also need the position at the start of the opentag/closetag (<). This patch introduces a property startTagPosition on the parser that can be used for this purpose.
