### PR TITLE
Test for #18

### DIFF
--- a/test/script.js
+++ b/test/script.js
@@ -1,0 +1,12 @@
+require(__dirname).test({
+  xml : "<html><head><script>if (1 < 0) { console.log('elo there'); }</script></head></script>",
+  expect : [
+    ["opentag", {"name": "HTML","attributes": {}}],
+    ["opentag", {"name": "HEAD","attributes": {}}],
+    ["opentag", {"name": "SCRIPT","attributes": {}}],
+    ["text", "if (1 < 0) { console.log('elo there'); }"],
+    ["closetag", "SCRIPT"],
+    ["closetag", "HEAD"],
+    ["closetag", "SCRIPT"]
+  ]
+});


### PR DESCRIPTION
Test: script tag contents containing '<' cause the parser to fail. '>' seems to be ok from limited testing
