### PR TITLE
Parsing entities cause a bug when there are multiples parameters in a link href

### DIFF
--- a/test/entities.js
+++ b/test/entities.js
@@ -1,0 +1,32 @@
+// testing links with one parameter
+require(__dirname).test({ 
+  xml : "<a href='http:www.google.com?arg1=test'>Lien</a>"
+  , expect :
+  [ [ "attribute", { name: "href", value: "http:www.google.com?arg1=test" } ]
+  ,[ "opentag", { name: "A", attributes: {
+    href : 'http:www.google.com?arg1=test'
+  }
+  } ]
+, [ "text", "Lien" ]
+  , [ "closetag", "A" ]
+  ]
+  , strict : false
+  , opt : {}
+});
+
+// testing links with two parameters
+require(__dirname).test({ 
+  xml : "<a href='http:www.google.com?arg1=test&arg2=value'>Mon Lien</a>"
+  , expect :
+  [ [ "attribute", { name: "href", value: "http:www.google.com?arg1=test&arg2=value" } ]
+  ,[ "opentag", { name: "A", attributes: {
+    href : 'http:www.google.com?arg1=test&arg2=value'
+  }
+  } ]
+, [ "text", "Mon Lien" ]
+  , [ "closetag", "A" ]
+  ]
+  , strict : false
+  , opt : {}
+});
+


### PR DESCRIPTION
Hello !
We found a little bug when trying to parse the following HTML :

``` html
<a href='http://www.google.com?arg1=test&arg2=value'>Mon Lien</a>
```

In the current state the parser returns this :

``` html
<a href='http://www.google.com?arg1=test&arg2value'>Mon Lien</a>
```

The returned HTML is wrong as there is a missing '=' (equal sign) in the second parameter.

I pulled a test case named 'entity.js' that show the problem.
Do you think it could be a good idea to add an option "ignoreEntities" that would not parse entities ?

Thank you !
