### PR TITLE
add nbsp to sax.ENTITIES

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -288,6 +288,7 @@ sax.ENTITIES =
 , "amp"  : "&"
 , "gt"   : ">"
 , "lt"   : "<"
+, "nbsp" : " "
 }
 
 for (var S in sax.STATE) sax.STATE[sax.STATE[S]] = S


### PR DESCRIPTION
add nbsp to sax.ENTITIES.  it looks like you want to add support for all HTML 4 entities (https://github.com/isaacs/sax-js/issues/42).  this is a start.
