### PR TITLE
Unclosed root tag error when in strict mode

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -350,6 +350,7 @@ function error (parser, er) {
 }
 
 function end (parser) {
+  if (!parser.closedRoot) strictFail(parser, "Unclosed root tag");
   if (parser.state !== S.TEXT) error(parser, "Unexpected end")
   closeText(parser)
   parser.c = ""

--- a/test/unclosed-root.js
+++ b/test/unclosed-root.js
@@ -1,0 +1,11 @@
+require(__dirname).test
+  ( { xml : "<root>"
+
+    , expect :
+      [ [ "opentag", { name: "root", attributes: {} } ]
+      , [ "error", "Unclosed root tag\nLine: 0\nColumn: 6\nChar: " ]
+      ]
+    , strict : true
+    , opt : {}
+    }
+  )


### PR DESCRIPTION
To resolve issue https://github.com/isaacs/sax-js/issues/60

'unclosed-root' test added
