### PR TITLE
README appears to have a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ through unmolested.
     // same chunks coming in also go out.
     fs.createReadStream("file.xml")
       .pipe(saxStream)
-      .pipe(fs.createReadStream("file-copy.xml"))
+      .pipe(fs.createWriteStream("file-copy.xml"))
 
 
 


### PR DESCRIPTION
It looks to me like the README has a typo in the stream piping example:

```
.pipe(fs.createReadStream("file-copy.xml"))
```

should be

```
.pipe(fs.createWriteStream("file-copy.xml"))
```
