### PR TITLE
Fix #84 Failing on unmatched quotes inside <?PI ?>

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -290,7 +290,6 @@ sax.STATE =
 , CDATA_ENDING_2            : S++ // ]]
 , PROC_INST                 : S++ // <?hi
 , PROC_INST_BODY            : S++ // <?hi there
-, PROC_INST_QUOTED          : S++ // <?hi "there
 , PROC_INST_ENDING          : S++ // <?hi "there" ?
 , OPEN_TAG                  : S++ // <strong
 , OPEN_TAG_SLASH            : S++ // <strong /
@@ -821,11 +820,7 @@ function write (chunk) {
       case S.PROC_INST_BODY:
         if (!parser.procInstBody && is(whitespace, c)) continue
         else if (c === "?") parser.state = S.PROC_INST_ENDING
-        else if (is(quote, c)) {
-          parser.state = S.PROC_INST_QUOTED
-          parser.q = c
-          parser.procInstBody += c
-        } else parser.procInstBody += c
+        else parser.procInstBody += c
       continue
 
       case S.PROC_INST_ENDING:
@@ -839,14 +834,6 @@ function write (chunk) {
         } else {
           parser.procInstBody += "?" + c
           parser.state = S.PROC_INST_BODY
-        }
-      continue
-
-      case S.PROC_INST_QUOTED:
-        parser.procInstBody += c
-        if (c === parser.q) {
-          parser.state = S.PROC_INST_BODY
-          parser.q = ""
         }
       continue
 

--- a/test/issue-84.js
+++ b/test/issue-84.js
@@ -1,0 +1,15 @@
+// https://github.com/isaacs/sax-js/issues/49
+require(__dirname).test
+  ( { xml : "<?has unbalanced \"quotes?><xml>body</xml>"
+    , expect :
+      [ [ "processinginstruction", { name: "has", body: "unbalanced \"quotes" } ],
+        [ "opentag", { name: "xml", attributes: {} } ]
+      , [ "text", "body" ]
+      , [ "closetag", "xml" ]
+      ]
+    , strict : false
+    , opt : { lowercasetags: true, noscript: true }
+    }
+  )
+
+


### PR DESCRIPTION
The XML spec defines processing instructions as:

PI ::= '<?' PITarget (S (Char\* - (Char\* '?>' Char*)))? '?>'
PITarget ::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))

( http://www.w3.org/TR/REC-xml/#sec-pi )

This does not require quotes inside the processing instruction to match.
The code, however, was entering and exiting a special state
(PROC_INST_QUOTED) for quotes as it hit them. This caused it to
incorrectly error out on unmatched quotes.  This commit removes
PROC_INST_QUOTED.
