### PR TITLE
better handling of closing script tags

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -518,6 +518,18 @@ function closeTag (parser) {
     parser.state = S.TEXT
     return
   }
+
+  if (parser.script) {
+    if (parser.tagName !== "script") {
+      parser.script += "</" + parser.tagName + ">"
+      parser.tagName = ""
+      parser.state = S.SCRIPT
+      return
+    }
+    emitNode(parser, "onscript", parser.script)
+    parser.script = ""
+  }
+
   // first make sure that the closing tag actually exists.
   // <a><b></c></b></a> will close everything, otherwise.
   var t = parser.tags.length
@@ -649,10 +661,7 @@ function write (chunk) {
 
       case S.SCRIPT_ENDING:
         if (c === "/") {
-          emitNode(parser, "onscript", parser.script)
           parser.state = S.CLOSE_TAG
-          parser.script = ""
-          parser.tagName = ""
         } else {
           parser.script += "<" + c
           parser.state = S.SCRIPT
@@ -951,13 +960,22 @@ function write (chunk) {
       case S.CLOSE_TAG:
         if (!parser.tagName) {
           if (is(whitespace, c)) continue
-          else if (not(nameStart, c)) strictFail(parser,
-            "Invalid tagname in closing tag.")
-          else parser.tagName = c
+          else if (not(nameStart, c)) {
+            if (parser.script) {
+              parser.script += "</" + c
+              parser.state = S.SCRIPT
+            } else {
+              strictFail(parser, "Invalid tagname in closing tag.")
+            }
+          } else parser.tagName = c
         }
         else if (c === ">") closeTag(parser)
         else if (is(nameBody, c)) parser.tagName += c
-        else {
+        else if (parser.script) {
+          parser.script += "</" + parser.tagName
+          parser.tagName = ""
+          parser.state = S.SCRIPT
+        } else {
           if (not(whitespace, c)) strictFail(parser,
             "Invalid tagname in closing tag")
           parser.state = S.CLOSE_TAG_SAW_WHITE

--- a/test/script.js
+++ b/test/script.js
@@ -10,3 +10,16 @@ require(__dirname).test({
     ["closetag", "HTML"]
   ]
 });
+
+require(__dirname).test({
+  xml : "<html><head><script>'<div>foo</div></'</script></head></html>",
+  expect : [
+    ["opentag", {"name": "HTML","attributes": {}}],
+    ["opentag", {"name": "HEAD","attributes": {}}],
+    ["opentag", {"name": "SCRIPT","attributes": {}}],
+    ["script", "'<div>foo</div></'"],
+    ["closetag", "SCRIPT"],
+    ["closetag", "HEAD"],
+    ["closetag", "HTML"]
+  ]
+});


### PR DESCRIPTION
Scripts can contain tag characters within their bounds (string,
templates, etc). These characters should not cause the script tag to
appear closed. Wait for an actual script tag closure.

Note that the presence of the full string "</script>" within the tag
will still cause termination as no checking for quotes or other
specifics is done. This just expands the termination check slightly.
