### PR TITLE
Expose isSelfClosing to onopentag

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -493,6 +493,8 @@ function openTag (parser, selfClosing) {
     parser.attribList.length = 0
   }
 
+  parser.tag.isSelfClosing = selfClosing;
+
   // process the tag
   parser.sawRoot = true
   parser.tags.push(parser.tag)


### PR DESCRIPTION
Currently the consumer of onopentag has no idea whether or not the tag was self-closing. The information is easily available, so I added it to the parser.tag object that is passed to the event.
