### PR TITLE
Fix global leak due to passing null context in Stream.apply()

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -158,7 +158,7 @@ function createStream (strict, opt) {
 function SAXStream (strict, opt) {
   if (!(this instanceof SAXStream)) return new SAXStream(strict, opt)
 
-  Stream.apply(me)
+  Stream.apply(this)
 
   this._parser = new SAXParser(strict, opt)
   this.writable = true


### PR DESCRIPTION
Because `this` doesn't get assigned to  `me` until a few lines below `Stream.apply()`, it turns out that the apply has `null` scope. That, in turn, means that when the `Stream` constructor calls `events.EventEmitter.call(this)`, `this` is null, i.e., global. And then, as a result, references to `this.domain`, `this._events` and `this._maxListeners` in `events` wind up leaking into the global scope.

Thanks for the awesome lib.
