### PR TITLE
Should fix issue #98

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -664,9 +664,8 @@ function qname (name) {
 function attrib (parser) {
   if (!parser.strict) parser.attribName = parser.attribName[parser.looseCase]()
 
-  if (parser.attribList.hasOwnProperty(parser.attribName) ||
-      parser.tag.attributes.hasOwnProperty(parser.attribName)) {
-   return parser.attribName = parser.attribValue = ""
+  if (parser.tag.attributes[parser.attribName]) {
+    return parser.attribName = parser.attribValue = ""
   }
 
   if (parser.opt.xmlns) {

--- a/test/attribute-name.js
+++ b/test/attribute-name.js
@@ -1,0 +1,33 @@
+require(__dirname).test(
+  { xml: "<root length='12345'></root>"
+  , expect: [
+    ["attribute", {
+      name: "length"
+    , value: "12345"
+    , prefix: ""
+    , local: "length"
+    , uri: ""
+    }]
+  , ["opentag", {
+      name: "root"
+    , prefix: ""
+    , local: "root"
+    , uri: ""
+    , attributes: {
+      length: {
+        name: "length"
+      , value: "12345"
+      , prefix: ""
+      , local: "length"
+      , uri: ""
+      }
+    }
+    , ns: {}
+    , isSelfClosing: false
+    }]
+  , ["closetag", "root"]
+  ]
+  , strict: true
+  , opt: { xmlns: true }
+  }
+)


### PR DESCRIPTION
Not sure if this is sufficient. Tests pass. 

Besides, it's not totally clear to me why duplicate attributes have to be guarded. Why not let them overwrite each other and let the last one win? I guess to prevent duplicate attribute events with the same name. Maybe users could handle these themselves.
