### PR TITLE
parser.pause()

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ event. Then, when the error is taken care of, you can call `resume` to
 continue parsing. Otherwise, the parser will not continue while in an error
 state.
 
+`pause` - To pause the parser. No events will be emitted before the next
+call to `resume()`.
+
 ## Members
 
 At all times, the parser object will have the following members:

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -62,6 +62,12 @@ function SAXParser (strict, opt) {
   parser.ENTITIES = Object.create(sax.ENTITIES)
   parser.attribList = []
 
+  parser.paused = false
+  parser.resuming = false
+  parser.ending = false
+
+  parser._buffers = []
+
   // namespaces form a prototype chain.
   // it always points at the current tag,
   // which protos to its parent tag.
@@ -136,8 +142,16 @@ function clearBuffers (parser) {
 SAXParser.prototype =
   { end: function () { end(this) }
   , write: write
-  , resume: function () { this.error = null; return this }
-  , close: function () { return this.write(null) }
+  , pause: pause
+  , resume: resume
+  , close: function () {
+      if (this.paused) {
+        this.ending = true
+      } else {
+        this.end()
+      }
+      return this
+    }
   }
 
 try {
@@ -620,13 +634,17 @@ function error (parser, er) {
 }
 
 function end (parser) {
-  if (!parser.closedRoot) strictFail(parser, "Unclosed root tag")
-  if (parser.state !== S.TEXT) error(parser, "Unexpected end")
-  closeText(parser)
-  parser.c = ""
-  parser.closed = true
-  emit(parser, "onend")
-  SAXParser.call(parser, parser.strict, parser.opt)
+  if (! parser.paused) {
+    if (!parser.closedRoot) strictFail(parser, "Unclosed root tag")
+    if (parser.state !== S.TEXT) error(parser, "Unexpected end")
+    closeText(parser)
+    parser.c = ""
+    parser.closed = true
+    emit(parser, "onend")
+    SAXParser.call(parser, parser.strict, parser.opt)
+  } else {
+    parser.ending = true
+  }
   return parser
 }
 
@@ -881,6 +899,23 @@ function parseEntity (parser) {
   return String.fromCharCode(num)
 }
 
+function resume () {
+  this.error = null
+  this.resuming = true
+  this.paused = false
+  while (this.resuming && this._buffers.length) {
+    this.write(this._buffers.shift())
+  }
+  this.resuming = false
+  return this
+}
+
+function pause () {
+  this.resuming = false
+  this.paused = true
+  return this
+}
+
 function write (chunk) {
   var parser = this
   if (this.error) throw this.error
@@ -889,6 +924,10 @@ function write (chunk) {
   if (chunk === null) return end(parser)
   var i = 0, c = ""
   while (parser.c = c = chunk.charAt(i++)) {
+    if (parser.paused && ! parser.resuming) {
+      parser._buffers.push(chunk.substring(i - 1))
+      return
+    }
     if (parser.trackPosition) {
       parser.position ++
       if (c === "\n") {
@@ -1310,6 +1349,11 @@ function write (chunk) {
   //   parser.cdata = ""
   // }
   if (parser.position >= parser.bufferCheckPosition) checkBufferLength(parser)
+
+  if (! parser.paused || parser.resuming) {
+    if (parser._buffers.length === 0 && parser.ending) parser.end()
+  }
+
   return parser
 }
 

--- a/test/pause.js
+++ b/test/pause.js
@@ -1,0 +1,2126 @@
+var sax = require("../lib/sax")
+  , parser = sax.parser()
+  , assert = require("assert")
+  , inspect = require('util').inspect
+  ;
+
+var paused = false
+
+var events = [];
+
+var expected = [
+  [
+    "attribute",
+    [
+      {
+        "name": "XMLNS:XSI",
+        "value": "http://www.w3.org/2001/XMLSchema-instance"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "VERSION",
+        "value": "2.0"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "XSI:NONAMESPACESCHEMALOCATION",
+        "value": "vast.xsd"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "VAST",
+        "attributes": {
+          "XMLNS:XSI": "http://www.w3.org/2001/XMLSchema-instance",
+          "VERSION": "2.0",
+          "XSI:NONAMESPACESCHEMALOCATION": "vast.xsd"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ID",
+        "value": "223626102"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "AD",
+        "attributes": {
+          "ID": "223626102"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "INLINE",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "VERSION",
+        "value": "2.0"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "ADSYSTEM",
+        "attributes": {
+          "VERSION": "2.0"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "DART_DFA"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "ADSYSTEM"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "ADTITLE",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "In-Stream Video"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "ADTITLE"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "DESCRIPTION",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "A test creative with a description."
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "DESCRIPTION"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "SURVEY",
+        "attributes": {},
+        "isSelfClosing": true
+      }
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "SURVEY"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ID",
+        "value": "DART"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "IMPRESSION",
+        "attributes": {
+          "ID": "DART"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/imp;v7;x;223626102;0-0;0;47414672;0/0;30477563/30495440/1;;~aopt=0/0/ff/0;~cs=j%3fhttp://s0.2mdn.net/dot.gif\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "IMPRESSION"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ID",
+        "value": "ThirdParty"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "IMPRESSION",
+        "attributes": {
+          "ID": "ThirdParty"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/ad/N270.Process_Other/B3473145;sz=1x1;ord=7753381?\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "IMPRESSION"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "CREATIVES",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "SEQUENCE",
+        "value": "1"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ADID",
+        "value": ""
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "CREATIVE",
+        "attributes": {
+          "SEQUENCE": "1",
+          "ADID": ""
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "LINEAR",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "DURATION",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "00:00:58"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "DURATION"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKINGEVENTS",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "start"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "start"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=11;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "midpoint"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "midpoint"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=18;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "midpoint"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "midpoint"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/ad/N270.Process_Other/B3473145.3;sz=1x1;ord=7753381?\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "firstQuartile"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "firstQuartile"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=26;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "firstQuartile"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "firstQuartile"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/ad/N270.Process_Other/B3473145.2;sz=1x1;ord=7753381?\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "thirdQuartile"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "thirdQuartile"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=27;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "thirdQuartile"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "thirdQuartile"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/ad/N270.Process_Other/B3473145.4;sz=1x1;ord=7753381?\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "complete"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "complete"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=13;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "complete"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "complete"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/ad/N270.Process_Other/B3473145.5;sz=1x1;ord=7753381?\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "mute"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "mute"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=16;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "pause"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "pause"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=15;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "fullscreen"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "fullscreen"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=19;ecn1=1;etm1=0;\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "EVENT",
+        "value": "fullscreen"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "TRACKING",
+        "attributes": {
+          "EVENT": "fullscreen"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/ad/N270.Process_Other/B3473145.6;sz=1x1;ord=7753381?\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "TRACKINGEVENTS"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "ADPARAMETERS",
+        "attributes": {},
+        "isSelfClosing": true
+      }
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "ADPARAMETERS"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "VIDEOCLICKS",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "CLICKTHROUGH",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      " http://www.google.com/support/richmedia "
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "CLICKTHROUGH"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ID",
+        "value": "DART"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "CLICKTRACKING",
+        "attributes": {
+          "ID": "DART"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/click%3Bh%3Dv8/3c41/3/0/%2a/z%3B223626102%3B0-0%3B0%3B47414672%3B255-0/0%3B30477563/30495440/1%3B%3B%7Eaopt%3D0/0/ff/0%3B%7Esscs%3D%3fhttp://s0.2mdn.net/dot.gif\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "CLICKTRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ID",
+        "value": "ThirdParty"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "CLICKTRACKING",
+        "attributes": {
+          "ID": "ThirdParty"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://ad.doubleclick.net/clk;212442087;33815766;i?http://www.google.com/support/richmedia\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "CLICKTRACKING"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "VIDEOCLICKS"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "MEDIAFILES",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ID",
+        "value": "1"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "DELIVERY",
+        "value": "progressive"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "TYPE",
+        "value": "video/x-flv"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "BITRATE",
+        "value": "457"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "WIDTH",
+        "value": "300"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "HEIGHT",
+        "value": "225"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "MEDIAFILE",
+        "attributes": {
+          "ID": "1",
+          "DELIVERY": "progressive",
+          "TYPE": "video/x-flv",
+          "BITRATE": "457",
+          "WIDTH": "300",
+          "HEIGHT": "225"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nhttp://rmcdn.2mdn.net/MotifFiles/html/2215309/PID_914438_1235753019000_dcrmvideo.flv\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "MEDIAFILE"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ID",
+        "value": "2"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "DELIVERY",
+        "value": "streaming"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "TYPE",
+        "value": "video/x-flv"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "BITRATE",
+        "value": "457"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "WIDTH",
+        "value": "300"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "HEIGHT",
+        "value": "225"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "MEDIAFILE",
+        "attributes": {
+          "ID": "2",
+          "DELIVERY": "streaming",
+          "TYPE": "video/x-flv",
+          "BITRATE": "457",
+          "WIDTH": "300",
+          "HEIGHT": "225"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      "\nrtmp://rmcdn.f.2mdn.net/ondemand/MotifFiles/html/2215309/PID_914438_1235753019000_dcrmvideo.flv\n"
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "MEDIAFILE"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "MEDIAFILES"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "LINEAR"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "CREATIVE"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "SEQUENCE",
+        "value": "1"
+      }
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "ADID",
+        "value": ""
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "CREATIVE",
+        "attributes": {
+          "SEQUENCE": "1",
+          "ADID": ""
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "COMPANIONADS",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "COMPANIONADS"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "CREATIVE"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "CREATIVES"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "EXTENSIONS",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "attribute",
+    [
+      {
+        "name": "TYPE",
+        "value": "DART"
+      }
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "EXTENSION",
+        "attributes": {
+          "TYPE": "DART"
+        },
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "ADSERVINGDATA",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "DELIVERYDATA",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opentag",
+    [
+      {
+        "name": "GEODATA",
+        "attributes": {},
+        "isSelfClosing": false
+      }
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "opencdata",
+    [
+      null
+    ]
+  ],
+  [
+    "cdata",
+    [
+      " ct=PT&st=&ac=21&zp=&bw=2&dma=1&city=11349 "
+    ]
+  ],
+  [
+    "closecdata",
+    [
+      null
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "GEODATA"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "DELIVERYDATA"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "ADSERVINGDATA"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "EXTENSION"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "EXTENSIONS"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "INLINE"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "AD"
+    ]
+  ],
+  [
+    "text",
+    [
+      "\n"
+    ]
+  ],
+  [
+    "closetag",
+    [
+      "VAST"
+    ]
+  ]
+];
+
+
+sax.EVENTS.forEach(function(ev) {
+  var methodName = 'on' + ev
+  parser[methodName] = function() {
+    events.push([ev, Array.prototype.slice.call(arguments)])
+    assert.ok(! paused, 'paused')
+  }
+})
+
+var xml = require('fs').readFileSync(__dirname + '/pause.xml', 'utf8')
+
+var chunkLength = 100;
+var currentIndex = 0;
+
+function resume() {
+  paused = false
+  parser.resume()
+  var chunk = xml.substring(currentIndex, currentIndex + chunkLength)
+  currentIndex += chunkLength
+  parser.write(chunk)
+  if (chunk.length === chunkLength) {
+    pause()
+    // send a chunk while it's paused
+    chunk = xml.substring(currentIndex, currentIndex + chunkLength)
+    parser.write(chunk) // this should not trigger any event, only when resumed
+    currentIndex += chunkLength
+    process.nextTick(resume)
+  } else {
+    parser.close()
+  }
+}
+
+parser.onend = function() {
+  assert.strictEqual(JSON.stringify(expected), JSON.stringify(events));
+}
+
+function pause() {
+  paused = true
+  parser.pause()
+}
+
+resume();

--- a/test/pause.xml
+++ b/test/pause.xml
@@ -1,0 +1,136 @@
+<VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:noNamespaceSchemaLocation="vast.xsd">
+<Ad id="223626102">
+<InLine>
+<AdSystem version="2.0">DART_DFA</AdSystem>
+<AdTitle>In-Stream Video</AdTitle>
+<Description>A test creative with a description.</Description>
+<Survey/>
+<Impression id="DART">
+<![CDATA[
+http://ad.doubleclick.net/imp;v7;x;223626102;0-0;0;47414672;0/0;30477563/30495440/1;;~aopt=0/0/ff/0;~cs=j%3fhttp://s0.2mdn.net/dot.gif
+]]>
+</Impression>
+<Impression id="ThirdParty">
+<![CDATA[
+http://ad.doubleclick.net/ad/N270.Process_Other/B3473145;sz=1x1;ord=7753381?
+]]>
+</Impression>
+<Creatives>
+<Creative sequence="1" AdID="">
+<Linear>
+<Duration>00:00:58</Duration>
+<TrackingEvents>
+<Tracking event="start">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=11;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="midpoint">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=18;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="midpoint">
+<![CDATA[
+http://ad.doubleclick.net/ad/N270.Process_Other/B3473145.3;sz=1x1;ord=7753381?
+]]>
+</Tracking>
+<Tracking event="firstQuartile">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=26;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="firstQuartile">
+<![CDATA[
+http://ad.doubleclick.net/ad/N270.Process_Other/B3473145.2;sz=1x1;ord=7753381?
+]]>
+</Tracking>
+<Tracking event="thirdQuartile">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=27;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="thirdQuartile">
+<![CDATA[
+http://ad.doubleclick.net/ad/N270.Process_Other/B3473145.4;sz=1x1;ord=7753381?
+]]>
+</Tracking>
+<Tracking event="complete">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=13;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="complete">
+<![CDATA[
+http://ad.doubleclick.net/ad/N270.Process_Other/B3473145.5;sz=1x1;ord=7753381?
+]]>
+</Tracking>
+<Tracking event="mute">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=16;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="pause">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=15;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="fullscreen">
+<![CDATA[
+http://ad.doubleclick.net/activity;src=2215309;met=1;v=1;pid=47414672;aid=223626102;ko=0;cid=30477563;rid=30495440;rv=1;timestamp=7753381;eid1=19;ecn1=1;etm1=0;
+]]>
+</Tracking>
+<Tracking event="fullscreen">
+<![CDATA[
+http://ad.doubleclick.net/ad/N270.Process_Other/B3473145.6;sz=1x1;ord=7753381?
+]]>
+</Tracking>
+</TrackingEvents>
+<AdParameters/>
+<VideoClicks>
+<ClickThrough>
+<![CDATA[ http://www.google.com/support/richmedia ]]>
+</ClickThrough>
+<ClickTracking id="DART">
+<![CDATA[
+http://ad.doubleclick.net/click%3Bh%3Dv8/3c41/3/0/%2a/z%3B223626102%3B0-0%3B0%3B47414672%3B255-0/0%3B30477563/30495440/1%3B%3B%7Eaopt%3D0/0/ff/0%3B%7Esscs%3D%3fhttp://s0.2mdn.net/dot.gif
+]]>
+</ClickTracking>
+<ClickTracking id="ThirdParty">
+<![CDATA[
+http://ad.doubleclick.net/clk;212442087;33815766;i?http://www.google.com/support/richmedia
+]]>
+</ClickTracking>
+</VideoClicks>
+<MediaFiles>
+<MediaFile id="1" delivery="progressive" type="video/x-flv" bitrate="457" width="300" height="225">
+<![CDATA[
+http://rmcdn.2mdn.net/MotifFiles/html/2215309/PID_914438_1235753019000_dcrmvideo.flv
+]]>
+</MediaFile>
+<MediaFile id="2" delivery="streaming" type="video/x-flv" bitrate="457" width="300" height="225">
+<![CDATA[
+rtmp://rmcdn.f.2mdn.net/ondemand/MotifFiles/html/2215309/PID_914438_1235753019000_dcrmvideo.flv
+]]>
+</MediaFile>
+</MediaFiles>
+</Linear>
+</Creative>
+<Creative sequence="1" AdID="">
+<CompanionAds></CompanionAds>
+</Creative>
+</Creatives>
+<Extensions>
+<Extension type="DART">
+<AdServingData>
+<DeliveryData>
+<GeoData>
+<![CDATA[ ct=PT&st=&ac=21&zp=&bw=2&dma=1&city=11349 ]]>
+</GeoData>
+</DeliveryData>
+</AdServingData>
+</Extension>
+</Extensions>
+</InLine>
+</Ad>
+</VAST>


### PR DESCRIPTION
Added support for parser.pause() with the following semantics:

After a parser.pause(), no events should be emitted before the next parser.resume(), even if parser.write() is invoked.

Needed to slightly modify:

parser.write(): to detect pauses and buffer the chunk if parser is paused.
parser.resume(): to resume all the pending buffers that were written while paused.
parser.pause(): to set the pausing state, to be detected in parser.write().
Added test test/pause.js that takes a large xml chunk, breaks it in pieces and:

asserts that no event is emitted while paused.
asserts that the order of all events is as expected.
Documented parser.pause in README.

This is pgte's code from https://github.com/isaacs/sax-js/pull/65 updated
to work with the latest sax-js.