### PR TITLE
Validate that there is whitespace between attributes in strict mode.

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -321,6 +321,7 @@ sax.STATE =
 , ATTRIB_NAME_SAW_WHITE     : S++ // <a foo _
 , ATTRIB_VALUE              : S++ // <a foo=
 , ATTRIB_VALUE_QUOTED       : S++ // <a foo="bar
+, ATTRIB_VALUE_CLOSED       : S++ // <a foo="bar"
 , ATTRIB_VALUE_UNQUOTED     : S++ // <a foo=bar
 , ATTRIB_VALUE_ENTITY_Q     : S++ // <foo bar="&quot;"
 , ATTRIB_VALUE_ENTITY_U     : S++ // <foo bar=&quot;
@@ -1237,7 +1238,20 @@ function write (chunk) {
         }
         attrib(parser)
         parser.q = ""
-        parser.state = S.ATTRIB
+        parser.state = S.ATTRIB_VALUE_CLOSED
+      continue
+
+      case S.ATTRIB_VALUE_CLOSED:
+        if (is(whitespace, c)) {
+          parser.state = S.ATTRIB
+        } else if (c === ">") openTag(parser)
+        else if (c === "/") parser.state = S.OPEN_TAG_SLASH
+        else if (is(nameStart, c)) {
+          strictFail(parser, "No whitespace between attributes")
+          parser.attribName = c
+          parser.attribValue = ""
+          parser.state = S.ATTRIB_NAME
+        } else strictFail(parser, "Invalid attribute name")
       continue
 
       case S.ATTRIB_VALUE_UNQUOTED:

--- a/test/attribute-no-space.js
+++ b/test/attribute-no-space.js
@@ -1,0 +1,75 @@
+// non-strict: no error
+require(__dirname).test
+  ( { xml : '<root attr1="first"attr2="second"/>'
+
+    , expect :
+      [ [ "attribute", { name: 'attr1', value: 'first' } ]
+      , [ "attribute", { name: 'attr2', value: 'second' } ]
+      , [ "opentag", { name: "root", attributes: {attr1: 'first', attr2: 'second'}, isSelfClosing: true } ]
+      , [ "closetag", "root" ]
+      ]
+    , strict : false
+    , opt : { lowercase: true }
+    }
+  )
+
+// strict: should give an error, but still parse
+require(__dirname).test
+  ( { xml : '<root attr1="first"attr2="second"/>'
+
+    , expect :
+      [ [ "attribute", { name: 'attr1', value: 'first' } ]
+      , [ "error", "No whitespace between attributes\nLine: 0\nColumn: 20\nChar: a" ]
+      , [ "attribute", { name: 'attr2', value: 'second' } ]
+      , [ "opentag", { name: "root", attributes: {attr1: 'first', attr2: 'second'}, isSelfClosing: true } ]
+      , [ "closetag", "root" ]
+      ]
+    , strict : true
+    , opt : { }
+    }
+  )
+
+// strict: other cases should still pass
+require(__dirname).test
+  ( { xml : '<root attr1="first" attr2="second"/>'
+
+    , expect :
+      [ [ "attribute", { name: 'attr1', value: 'first' } ]
+      , [ "attribute", { name: 'attr2', value: 'second' } ]
+      , [ "opentag", { name: "root", attributes: {attr1: 'first', attr2: 'second'}, isSelfClosing: true } ]
+      , [ "closetag", "root" ]
+      ]
+    , strict : true
+    , opt : { }
+    }
+  )
+
+// strict: other cases should still pass
+require(__dirname).test
+  ( { xml : '<root attr1="first"\nattr2="second"/>'
+
+    , expect :
+      [ [ "attribute", { name: 'attr1', value: 'first' } ]
+      , [ "attribute", { name: 'attr2', value: 'second' } ]
+      , [ "opentag", { name: "root", attributes: {attr1: 'first', attr2: 'second'}, isSelfClosing: true } ]
+      , [ "closetag", "root" ]
+      ]
+    , strict : true
+    , opt : { }
+    }
+  )
+
+// strict: other cases should still pass
+require(__dirname).test
+  ( { xml : '<root attr1="first"  attr2="second"/>'
+
+    , expect :
+      [ [ "attribute", { name: 'attr1', value: 'first' } ]
+      , [ "attribute", { name: 'attr2', value: 'second' } ]
+      , [ "opentag", { name: "root", attributes: {attr1: 'first', attr2: 'second'}, isSelfClosing: true } ]
+      , [ "closetag", "root" ]
+      ]
+    , strict : true
+    , opt : { }
+    }
+  )


### PR DESCRIPTION
Sample:

```
<root attr1="first"attr2="second"/>
```

I believe this should produce an error in strict mode, but not in non-strict mode.
