### PR TITLE
Ending 'empty' stream should not cause an error

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -633,7 +633,7 @@ function error (parser, er) {
 
 function end (parser) {
   if (!parser.closedRoot) strictFail(parser, "Unclosed root tag")
-  if (parser.state !== S.TEXT) error(parser, "Unexpected end")
+  if ((parser.state !== S.BEGIN) && (parser.state !== S.TEXT)) error(parser, "Unexpected end")
   closeText(parser)
   parser.c = ""
   parser.closed = true

--- a/test/end_empty_stream.js
+++ b/test/end_empty_stream.js
@@ -1,0 +1,5 @@
+var assert = require('assert');
+var saxStream = require('../lib/sax').createStream();
+assert.doesNotThrow(function() {
+    saxStream.end();
+});


### PR DESCRIPTION
- This situation can easily happen when piping a socket to the saxStream and the
  socket is disconnected before receiving any data.
- Add a simple test.
