### PR TITLE
Bugfix: sax is now able to handle a tag with the name "xmlns".

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -658,14 +658,14 @@ function newTag (parser) {
   parser.attribList.length = 0
 }
 
-function qname (name) {
+function qname (name, attribute) {
   var i = name.indexOf(":")
     , qualName = i < 0 ? [ "", name ] : name.split(":")
     , prefix = qualName[0]
     , local = qualName[1]
 
   // <x "xmlns"="http://foo">
-  if (name === "xmlns") {
+  if (attribute && name === "xmlns") {
     prefix = "xmlns"
     local = ""
   }
@@ -682,7 +682,7 @@ function attrib (parser) {
   }
 
   if (parser.opt.xmlns) {
-    var qn = qname(parser.attribName)
+    var qn = qname(parser.attribName, true)
       , prefix = qn.prefix
       , local = qn.local
 
@@ -755,7 +755,7 @@ function openTag (parser, selfClosing) {
       var nv = parser.attribList[i]
       var name = nv[0]
         , value = nv[1]
-        , qualName = qname(name)
+        , qualName = qname(name, true)
         , prefix = qualName.prefix
         , local = qualName.local
         , uri = prefix == "" ? "" : (tag.ns[prefix] || "")

--- a/test/xmlns-as-tag-name.js
+++ b/test/xmlns-as-tag-name.js
@@ -1,0 +1,15 @@
+
+require(__dirname).test
+  ( { xml :
+      "<xmlns/>"
+    , expect :
+      [ [ "opentag", { name: "xmlns", uri: "", prefix: "", local: "xmlns",
+                       attributes: {}, ns: {},
+                       isSelfClosing: true}
+        ],
+        ["closetag", "xmlns"]
+      ]
+    , strict : true
+    , opt : { xmlns: true }
+    }
+  );


### PR DESCRIPTION
Before this patch, sax-js would produce incorrect events if it had to handle a tag named `xmlns` in the input. Something like:

```
<xmlns/>
```

would trip it up. The local name would be the empty string and the prefix would be set to `xmlns`. I've modified the code so that this kind of transformation now happens only for attributes.

For the record, I came across this issue while running sax-js over a test suite designed by James Clark for Relax NG validators. I don't know what possessed him to test for `<xmlns/>` (maybe the same bug in another piece of software?), but here we are.
