### PR TITLE
Optionally leave HTML entities unparsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Settings supported:
   in loose mode, rather than uppercasing them.
 * `xmlns` - Boolean. If true, then namespaces are supported.
 * `position` - Boolean. If false, then don't track line/col/position.
-* `strictxml` - Boolean. If true, only parse XML entities (`&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;`)
+* `strictEntities` - Boolean. If true, only parse [predefined XML entities](http://www.w3.org/TR/REC-xml/#sec-predefined-ent) (`&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;`)
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the browser or other CommonJS implementations.
 
 * A very simple tool to parse through an XML string.
 * A stepping stone to a streaming HTML parser.
-* A handy way to deal with RSS and other mostly-ok-but-kinda-broken XML 
+* A handy way to deal with RSS and other mostly-ok-but-kinda-broken XML
   docs.
 
 ## What This Is (probably) Not
@@ -23,7 +23,7 @@ the browser or other CommonJS implementations.
   implementations are in Java and do a lot more than this does.
 * An XML Validator - It does a little validation when in strict mode, but
   not much.
-* A Schema-Aware XSD Thing - Schemas are an exercise in fetishistic 
+* A Schema-Aware XSD Thing - Schemas are an exercise in fetishistic
   masochism.
 * A DTD-aware Thing - Fetching DTDs is a much bigger job.
 
@@ -102,6 +102,7 @@ Settings supported:
   in loose mode, rather than uppercasing them.
 * `xmlns` - Boolean. If true, then namespaces are supported.
 * `position` - Boolean. If false, then don't track line/col/position.
+* `strictxml` - Boolean. If true, only parse XML entities (`&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;`)
 
 ## Methods
 

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -59,8 +59,8 @@ function SAXParser (strict, opt) {
   parser.strict = !!strict
   parser.noscript = !!(strict || parser.opt.noscript)
   parser.state = S.BEGIN
-  parser.strictxml = parser.opt.strictxml || parser.opt.strictEntities
-  parser.ENTITIES = parser.strictxml ? Object.create(sax.XML_ENTITIES) : Object.create(sax.ENTITIES)
+  parser.strictEntities = parser.opt.strictEntities
+  parser.ENTITIES = parser.strictEntities ? Object.create(sax.XML_ENTITIES) : Object.create(sax.ENTITIES)
   parser.attribList = []
 
   // namespaces form a prototype chain.

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -59,7 +59,8 @@ function SAXParser (strict, opt) {
   parser.strict = !!strict
   parser.noscript = !!(strict || parser.opt.noscript)
   parser.state = S.BEGIN
-  parser.ENTITIES = Object.create(sax.ENTITIES)
+  parser.strictxml = parser.opt.strictxml || parser.opt.strictEntities
+  parser.ENTITIES = parser.strictxml ? Object.create(sax.XML_ENTITIES) : Object.create(sax.ENTITIES)
   parser.attribList = []
 
   // namespaces form a prototype chain.
@@ -342,6 +343,14 @@ sax.STATE =
 , CLOSE_TAG_SAW_WHITE       : S++ // </a   >
 , SCRIPT                    : S++ // <script> ...
 , SCRIPT_ENDING             : S++ // <script> ... <
+}
+
+sax.XML_ENTITIES =
+{ "amp" : "&"
+, "gt" : ">"
+, "lt" : "<"
+, "quot" : "\""
+, "apos" : "'"
 }
 
 sax.ENTITIES =

--- a/test/xml_entities.js
+++ b/test/xml_entities.js
@@ -1,0 +1,11 @@
+require(__dirname).test({
+  opt: { strictEntities: true },
+  xml: '<r>&rfloor; ' +
+       '&spades; &copy; &rarr; &amp; ' +
+        '&lt; < <  <   < &gt; &real; &weierp; &euro;</r>',
+  expect: [
+    ['opentag', {'name':'R', attributes:{}, isSelfClosing: false}],
+    ['text', '&rfloor; &spades; &copy; &rarr; & < < <  <   < > &real; &weierp; &euro;'],
+    ['closetag', 'R']
+  ]
+});


### PR DESCRIPTION
Fixes https://github.com/isaacs/sax-js/issues/97

Exposes the `strictxml` or `strictEntities` option to the user, which when truth-y will only parse `&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;` and pass HTML entities (like `&int;`) unparsed.

Happy to change the name of the option or its implementation if requested.