### PR TITLE
Fixing version number

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "sax",
   "description": "An evented streaming XML parser in JavaScript",
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "main": "lib/sax.js",
   "license": "BSD",
   "scripts": [


### PR DESCRIPTION
Mismatch between tagged version and specified version number. 

``` shell
$ bower install
bower not-cached    https://github.com/isaacs/sax-js.git#*
bower resolve       https://github.com/isaacs/sax-js.git#*
bower checkout      sax#v0.6.0
bower deprecated    Package sax is using the deprecated component.json
bower mismatch      Version declared in the json (0.5.2) is different than the resolved one (0.6.0)
bower resolved      https://github.com/isaacs/sax-js.git#0.6.0
```
