### PR TITLE
stand-alone comment parser fix

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -646,7 +646,7 @@ function error (parser, er) {
 }
 
 function end (parser) {
-  if (!parser.closedRoot) strictFail(parser, "Unclosed root tag")
+  if (parser.sawRoot && !parser.closedRoot) strictFail(parser, "Unclosed root tag")
   if ((parser.state !== S.BEGIN) && (parser.state !== S.TEXT)) error(parser, "Unexpected end")
   closeText(parser)
   parser.c = ""

--- a/test/stand-alone-comment.js
+++ b/test/stand-alone-comment.js
@@ -1,0 +1,11 @@
+// https://github.com/isaacs/sax-js/issues/124
+require(__dirname).test
+  ( { xml : "<!-- stand alone comment -->"
+
+    , expect :
+      [ [ "comment", " stand alone comment " ] ]
+    , strict : true
+    , opt : {}
+    }
+  )
+


### PR DESCRIPTION
Addresses issue https://github.com/isaacs/sax-js/issues/124

Failure triggered for "Unclosed root tag" in end() assumes a root has been seen.  Fix adds a check to ensure a root has in fact been seen (sawRoot).  This fixes the stand-alone comment issues as filed in issue # 124 as the comment contains no root.