### PR TITLE
Missing semicolon breaks minified build

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1407,4 +1407,4 @@ if (!String.fromCodePoint) {
         }());
 }
 
-})(typeof exports === "undefined" ? sax = {} : exports)
+})(typeof exports === "undefined" ? sax = {} : exports);


### PR DESCRIPTION
The missing semicolon at the end of the file causes undesired behaviour when the file is concatenated to other js files.
