### PR TITLE
option to ignore entities processing

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1327,13 +1327,19 @@ function write (chunk) {
           break
         }
         if (c === ";") {
-          parser[buffer] += parseEntity(parser)
+          if (parser.opt.ignoreEntities) {
+            parser[buffer] += "&" + parser.entity + c
+          } else {
+            parser[buffer] += parseEntity(parser)
+          }
           parser.entity = ""
           parser.state = returnState
         }
         else if (is(entity, c)) parser.entity += c
         else {
-          strictFail(parser, "Invalid character entity")
+          if (!parser.opt.ignoreEntities) {
+            strictFail(parser, "Invalid character entity")
+          }
           parser[buffer] += "&" + parser.entity + c
           parser.entity = ""
           parser.state = returnState


### PR DESCRIPTION
hi.

I need this for [svgo](https://github.com/svg/svgo) because:
1. I need to serialize XML (SVG) parsed to AST back into a string that might be embebbed inline to HTML, so I need to preserve all the original entities "escaping"
2. entities declarations from doctype section should "works", i.e. just be ignored without `Invalid character entity` error
3. strict mode should still be turned on

so.. I just need to disable entities processing to keep text nodes and attrs values in the original state.
