### PR TITLE
Don't reject valid entity names

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1363,7 +1363,7 @@ function write (chunk) {
           } else if (!isEntityStart && is(entity, c)) {
             parser.entity += c
           } else {
-            strictFail(parser, "Invalid character entity")
+            strictFail(parser, "Invalid entity name")
             parser[buffer] += "&" + parser.entity + c
             parser.entity = ""
             parser.state = returnState

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -260,7 +260,8 @@ var whitespace = "\r\n\t "
   , letter = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
   // (Letter | "_" | ":")
   , quote = "'\""
-  , entity = number+letter+"#"
+  , entityStart = letter+":_#"
+  , entity = entityStart+number+"-."
   , attribEnd = whitespace + ">"
   , CDATA = "[CDATA["
   , DOCTYPE = "DOCTYPE"
@@ -285,6 +286,7 @@ var nameBody = /[:_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u0
 
 quote = charClass(quote)
 entity = charClass(entity)
+entityStart = charClass(entityStart)
 attribEnd = charClass(attribEnd)
 
 function charClass (str) {
@@ -928,6 +930,7 @@ function write (chunk) {
     "Cannot write after close. Assign an onready handler.")
   if (chunk === null) return end(parser)
   var i = 0, c = ""
+  var isEntityStart = false
   while (parser.c = c = chunk.charAt(i++)) {
     if (parser.trackPosition) {
       parser.position ++
@@ -979,7 +982,10 @@ function write (chunk) {
         } else {
           if (not(whitespace, c) && (!parser.sawRoot || parser.closedRoot))
             strictFail(parser, "Text data outside of root node.")
-          if (c === "&") parser.state = S.TEXT_ENTITY
+          if (c === "&") {
+            parser.state = S.TEXT_ENTITY
+            isEntityStart = true
+          }
           else parser.textNode += c
         }
       continue
@@ -1351,12 +1357,18 @@ function write (chunk) {
           parser.entity = ""
           parser.state = returnState
         }
-        else if (is(entity, c)) parser.entity += c
         else {
-          strictFail(parser, "Invalid character entity")
-          parser[buffer] += "&" + parser.entity + c
-          parser.entity = ""
-          parser.state = returnState
+          if (isEntityStart && is(entityStart, c)) {
+            parser.entity += c
+          } else if (!isEntityStart && is(entity, c)) {
+            parser.entity += c
+          } else {
+            strictFail(parser, "Invalid character entity")
+            parser[buffer] += "&" + parser.entity + c
+            parser.entity = ""
+            parser.state = returnState
+          }
+          isEntityStart = false;
         }
       continue
 


### PR DESCRIPTION
Entity names allow more characters than just letters an numbers, see:
http://www.w3.org/TR/REC-xml/#sec-common-syn

This commit does not handle non-ASCII characters in the names, though.

This should fix #139 as well.