### PR TITLE
Add a third argument to SAXStream.prototype.end

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -229,9 +229,10 @@ SAXStream.prototype.write = function (data) {
   return true
 }
 
-SAXStream.prototype.end = function (chunk) {
+SAXStream.prototype.end = function (chunk, encoding, callback) {
   if (chunk && chunk.length) this.write(chunk)
   this._parser.end()
+  callback()
   return true
 }
 


### PR DESCRIPTION
Fixes #143.
The end method should accept a third argument that is a callback to call when the stream is finished.
http://nodejs.org/api/stream.html#stream_writable_end_chunk_encoding_callback