### PR TITLE
Ignore BOM at the beginning of the stream

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -307,7 +307,8 @@ function not (charclass, c) {
 
 var S = 0
 sax.STATE =
-{ BEGIN                     : S++
+{ BEGIN                     : S++ // leading byte order mark or whitespace
+, BEGIN_WHITESPACE          : S++ // leading whitespace
 , TEXT                      : S++ // general stuff
 , TEXT_ENTITY               : S++ // &amp and such.
 , OPEN_WAKA                 : S++ // <
@@ -647,7 +648,7 @@ function error (parser, er) {
 
 function end (parser) {
   if (!parser.closedRoot) strictFail(parser, "Unclosed root tag")
-  if ((parser.state !== S.BEGIN) && (parser.state !== S.TEXT)) error(parser, "Unexpected end")
+  if ((parser.state !== S.BEGIN) && (parser.state !== S.BEGIN_WHITESPACE) && (parser.state !== S.TEXT)) error(parser, "Unexpected end")
   closeText(parser)
   parser.c = ""
   parser.closed = true
@@ -926,6 +927,13 @@ function write (chunk) {
     switch (parser.state) {
 
       case S.BEGIN:
+        parser.state = S.BEGIN_WHITESPACE
+        if (c === "\uFEFF") {
+          continue;
+        }
+      // no continue - fall through
+
+      case S.BEGIN_WHITESPACE:
         if (c === "<") {
           parser.state = S.OPEN_WAKA
           parser.startTagPosition = parser.position

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -929,7 +929,7 @@ function write (chunk) {
         if (c === "<") {
           parser.state = S.OPEN_WAKA
           parser.startTagPosition = parser.position
-        } else if (not(whitespace,c)) {
+        } else if (not(whitespace,c) && c!=="\uFEFF") {
           // have to process this as a text node.
           // weird, but happens.
           strictFail(parser, "Non-whitespace before first tag.")

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -929,7 +929,7 @@ function write (chunk) {
         if (c === "<") {
           parser.state = S.OPEN_WAKA
           parser.startTagPosition = parser.position
-        } else if (not(whitespace,c) && c!=="\uFEFF") {
+        } else if (not(whitespace,c)) {
           // have to process this as a text node.
           // weird, but happens.
           strictFail(parser, "Non-whitespace before first tag.")

--- a/test/bom.js
+++ b/test/bom.js
@@ -1,0 +1,7 @@
+require(__dirname).test({
+  xml: '\uFEFF<Р></Р>',
+  expect: [
+    ['opentag', {'name':'Р', attributes:{}, isSelfClosing: false}],
+    ['closetag', 'Р']
+  ]
+});

--- a/test/bom.js
+++ b/test/bom.js
@@ -1,19 +1,44 @@
 // BOM at the very begining of the stream should be ignored
 require(__dirname).test({
-  xml: '\uFEFF<Р></Р>',
+  xml: '\uFEFF<P></P>',
   expect: [
-    ['opentag', {'name':'Р', attributes:{}, isSelfClosing: false}],
-    ['closetag', 'Р']
+    ['opentag', {'name':'P', attributes:{}, isSelfClosing: false}],
+    ['closetag', 'P']
   ]
 });
 
 // In all other places it should be consumed
 require(__dirname).test({
-  xml: '\uFEFF<Р BOM="\uFEFF">\uFEFFStarts and ends with BOM\uFEFF</Р>',
+  xml: '\uFEFF<P BOM="\uFEFF">\uFEFFStarts and ends with BOM\uFEFF</P>',
   expect: [
     ['attribute', {'name':'BOM', 'value':'\uFEFF'}],
-    ['opentag', {'name':'Р', attributes:{'BOM':'\uFEFF'}, isSelfClosing: false}],
+    ['opentag', {'name':'P', attributes:{'BOM':'\uFEFF'}, isSelfClosing: false}],
     ['text', '\uFEFFStarts and ends with BOM\uFEFF'],
-    ['closetag', 'Р']
+    ['closetag', 'P']
   ]
 });
+
+// BOM after a whitespace is an error
+require(__dirname).test({
+  xml: ' \uFEFF<P></P>',
+  expect: [
+    ['error', 'Non-whitespace before first tag.\nLine: 0\nColumn: 2\nChar: \uFEFF'],
+    ['text', '\uFEFF'],
+    ['opentag', {'name': 'P', attributes: {}, isSelfClosing: false}],
+    ['closetag', 'P'],
+  ],
+  strict: true
+});
+
+// There is only one BOM allowed at the start
+require(__dirname).test({
+  xml: '\uFEFF\uFEFF<P></P>',
+  expect: [
+    ['error', 'Non-whitespace before first tag.\nLine: 0\nColumn: 2\nChar: \uFEFF'],
+    ['text', '\uFEFF'],
+    ['opentag', {'name': 'P', attributes: {}, isSelfClosing: false}],
+    ['closetag', 'P'],
+  ],
+  strict: true
+});
+

--- a/test/bom.js
+++ b/test/bom.js
@@ -1,7 +1,19 @@
+// BOM at the very begining of the stream should be ignored
 require(__dirname).test({
   xml: '\uFEFF<Р></Р>',
   expect: [
     ['opentag', {'name':'Р', attributes:{}, isSelfClosing: false}],
+    ['closetag', 'Р']
+  ]
+});
+
+// In all other places it should be consumed
+require(__dirname).test({
+  xml: '\uFEFF<Р BOM="\uFEFF">\uFEFFStarts and ends with BOM\uFEFF</Р>',
+  expect: [
+    ['attribute', {'name':'BOM', 'value':'\uFEFF'}],
+    ['opentag', {'name':'Р', attributes:{'BOM':'\uFEFF'}, isSelfClosing: false}],
+    ['text', '\uFEFFStarts and ends with BOM\uFEFF'],
     ['closetag', 'Р']
   ]
 });


### PR DESCRIPTION
BOM at the start of the stram should be ignored, as [spec says](http://www.w3.org/TR/REC-xml/#charencoding),
> This [Byte Order Mark] is an encoding signature, not part of either the markup or the character data of the XML document.

So, there's a patch for this. And the test.

`\uFEFF` check is pretty straightforward here, I suppose, there's no sense in adding a special "whitespaceOrBom" character class or a special "S.THE_VERY_BEGIN" state for this special case.