### PR TITLE
fix RangeError exception when parsing entities

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -947,7 +947,7 @@
       }
     }
     entity = entity.replace(/^0+/, '')
-    if (numStr.toLowerCase() !== entity) {
+    if (isNaN(num) || numStr.toLowerCase() !== entity) {
       strictFail(parser, 'Invalid character entity')
       return '&' + parser.entity + ';'
     }

--- a/test/entity-nan.js
+++ b/test/entity-nan.js
@@ -1,0 +1,8 @@
+require(__dirname).test({
+  xml: '<r>&#NaN;</r>',
+  expect: [
+    ['opentag', {'name': 'R', attributes: {}, isSelfClosing: false}],
+    ['text', '&#NaN;'],
+    ['closetag', 'R']
+  ]
+})


### PR DESCRIPTION
Improve checking for invalid numerical entities so that we don't pass NaN to `String.fromCodePoint`

It could have happened for entities like `&#NaN;` since

```
parseInt('NaN').toString() === 'NaN'
```

Added explicit `isNaN()` check to declare the entity invalid.

fixes: #116
