### PR TITLE
Entities Parsing

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1358,7 +1358,7 @@ function write (chunk) {
         ) {
           parser.entity += c
         } else {
-          strictFail(parser, "Invalid character entity")
+          strictFail(parser, "Invalid character in entity name")
           parser[buffer] += "&" + parser.entity + c
           parser.entity = ""
           parser.state = returnState

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -260,7 +260,6 @@ var whitespace = "\r\n\t "
   , letter = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
   // (Letter | "_" | ":")
   , quote = "'\""
-  , entity = number+letter+"#"
   , attribEnd = whitespace + ">"
   , CDATA = "[CDATA["
   , DOCTYPE = "DOCTYPE"
@@ -283,8 +282,10 @@ var nameStart = /[:_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u
 
 var nameBody = /[:_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u00B7\u0300-\u036F\u203F-\u2040\.\d-]/
 
+var entityStart = /[#:_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/
+var entityBody =  /[#:_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u00B7\u0300-\u036F\u203F-\u2040\.\d-]/
+
 quote = charClass(quote)
-entity = charClass(entity)
 attribEnd = charClass(attribEnd)
 
 function charClass (str) {
@@ -1351,8 +1352,12 @@ function write (chunk) {
           parser.entity = ""
           parser.state = returnState
         }
-        else if (is(entity, c)) parser.entity += c
-        else {
+        else if (
+                 (!parser.entity.length && is(entityStart, c)) ||
+                 (parser.entity.length && is(entityBody, c))
+        ) {
+          parser.entity += c
+        } else {
           strictFail(parser, "Invalid character entity")
           parser[buffer] += "&" + parser.entity + c
           parser.entity = ""

--- a/test/xml_internal_entities.js
+++ b/test/xml_internal_entities.js
@@ -1,0 +1,58 @@
+var i_expect = [], my_attributes = {}, ENTITIES = {};
+
+//generates xml like test0="&control;"
+var entities_to_test= {
+//	'ENTITY_NAME':	IS_VALID || [invalid_char_pos, invalid_char],
+	'control0':		true,//This is a vanilla control.
+	//entityStart
+	'_uscore':		true,
+	'#hash':		true,
+	':colon': 		true,
+	'-bad': 		[0, '-'],
+	'.bad': 		[0, '.'],
+	//general entity
+	'u_score':		true,
+	'd-ash':		true,
+	'd.ot':			true,
+	'all:_#-.':		true,
+};
+
+var xml_start = '<a test="&amp;" ',
+	xml_end = '/>';
+
+i_expect.push(['attribute', {name: 'test', value: '&'}]);
+my_attributes['test'] = '&';
+
+var ent_i=0;
+
+
+for (entity in entities_to_test){
+	var attrib_name = "test"+ent_i, attrib_value = "Testing "+entity;
+	xml_start += attrib_name+'="'+'&';//add the first part to use in calculation below
+	if (typeof entities_to_test[entity] == "object"){
+		i_expect.push(['error', "Invalid character entity\nLine: 0\nColumn: "+(xml_start.length+entities_to_test[entity][0]+1)+"\nChar: "+entities_to_test[entity][1]]);
+		i_expect.push(['attribute', {name: attrib_name, value: '&'+entity+';'}]);
+		my_attributes[attrib_name] = '&'+entity+';';
+	} else {
+		ENTITIES[entity] = attrib_value;
+		i_expect.push(['attribute', {name: attrib_name, value: attrib_value}]);
+		my_attributes[attrib_name] = attrib_value;
+	}
+
+	xml_start += entity+';" ';
+	ent_i++;
+}
+
+i_expect.push(['opentag', {'name':'a', attributes:my_attributes, isSelfClosing: true}]);
+i_expect.push(['closetag', 'a']);
+
+var parser = require(__dirname).test({
+  strict: true,
+  expect: i_expect
+});
+
+for (entity in entities_to_test){
+	parser.ENTITIES[entity] = ENTITIES[entity];
+}
+
+parser.write(xml_start+xml_end).close();


### PR DESCRIPTION
Similar to #142, this handles parsing entities with a character class like nameStart/Body (Plus # character).

Sax-js would fail on some Adobe Illustrator exported SVG files.

Should fix #139 (includes test)