### PR TITLE
Check for invalid code points before passing them to String.fromCodePoint

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -947,7 +947,10 @@
       }
     }
     entity = entity.replace(/^0+/, '')
-    if (numStr.toLowerCase() !== entity) {
+    if (numStr.toLowerCase() !== entity ||
+      // Valid Unicode code points are numbers within the range 0 - 0x10FFFF
+      isNaN(num) || num < 0 || num > 0x10FFFF
+    ) {
       strictFail(parser, 'Invalid character entity')
       return '&' + parser.entity + ';'
     }

--- a/test/entities-invalid.js
+++ b/test/entities-invalid.js
@@ -1,0 +1,23 @@
+var invalidEntities = ['1114112', '-1', 'NaN']
+
+for (var i = invalidEntities.length - 1; i >= 0; --i) {
+  require(__dirname).test({
+    xml: '<r>&#' + invalidEntities[i] + ';</r>',
+    strict: false,
+    expect: [
+      ['opentag', {'name': 'R', attributes: {}, isSelfClosing: false}],
+      ['text', '&#' + invalidEntities[i] + ';'],
+      ['closetag', 'R']
+    ]
+  })
+  require(__dirname).test({
+    xml: '<r>&#' + invalidEntities[i] + ';</r>',
+    strict: true,
+    expect: [
+      ['opentag', {'name': 'r', attributes: {}, isSelfClosing: false}],
+      ['error', 'Invalid character entity\nLine: 0\nColumn: ' + (6 + invalidEntities[i].length) + '\nChar: ;'],
+      ['text', '&#' + invalidEntities[i] + ';'],
+      ['closetag', 'r']
+    ]
+  })
+}


### PR DESCRIPTION
- Now the call will not throw RangeError exceptions
- Tests are included for both strict: true and strict: false modes
- Fixes #116 and #160