### PR TITLE
Avoid a deopt when calling string.charAt(i)

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -968,6 +968,14 @@
     }
   }
 
+  function charAt (chunk, i) {
+    var result = ''
+    if (i < chunk.length) {
+      result = chunk.charAt(i)
+    }
+    return result
+  }
+
   function write (chunk) {
     var parser = this
     if (this.error) {
@@ -983,7 +991,7 @@
     var i = 0
     var c = ''
     while (true) {
-      c = chunk.charAt(i++)
+      c = charAt(chunk, i++)
       parser.c = c
       if (!c) {
         break
@@ -1014,7 +1022,7 @@
           if (parser.sawRoot && !parser.closedRoot) {
             var starti = i - 1
             while (c && c !== '<' && c !== '&') {
-              c = chunk.charAt(i++)
+              c = charAt(chunk, i++)
               if (c && parser.trackPosition) {
                 parser.position++
                 if (c === '\n') {


### PR DESCRIPTION
2x throughput increase when using streams: I cut down the time spent parsing a large XML (200MB+) file by half.