### PR TITLE
Make sure chunk is a string before calling charAt()

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -988,6 +988,9 @@
     if (chunk === null) {
       return end(parser)
     }
+    if (typeof chunk !== 'string') {
+      chunk = chunk.toString()
+    }
     var i = 0
     var c = ''
     while (true) {


### PR DESCRIPTION
Sometimes typeof(chunk) === 'object' which creates an error:

> G:\p\Node.js\tc-m\node_modules\sax\lib\sax.js:590
>   while (parser.c = c = chunk.charAt(i++)) {
>                               ^
> 
> TypeError: chunk.charAt is not a function
>     at Object.write (G:\p\Node.js\tc-m\node_modules\sax\lib\sax.js:590:31)
>     at FeedParser.write (G:\p\Node.js\tc-m\node_modules\feed-read\index.js:228:17)
>     at Function.FeedRead.rss (G:\p\Node.js\tc-m\node_modules\feed-read\index.js:191:10)
>     at Function.FeedRead.rss (G:\p\Node.js\tc-m\node_modules\feed-read\index.js:148:34)
>     at Object.FeedParser.rss [as parseRss] (G:\p\Node.js\tc-m\Services\ParsingService.js:5:14)
>     at IncomingMessage.<anonymous> (G:\p\Node.js\tc-m\app.js:17:24)
>     at emitOne (events.js:90:13)
>     at IncomingMessage.emit (events.js:182:7)
>     at readableAddChunk (_stream_readable.js:147:16)
>     at IncomingMessage.Readable.push (_stream_readable.js:111:10)

This pull request calls toString() on chunks which are not typeof string.

In my case this happened when trying to parse malformed RSS. By converting the object to a string I was presented with a more appropriate error message that the RSS was malformed.