### PR TITLE
Issue 168:  In strict mode, disallow more than one XML root.

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1081,6 +1081,12 @@
           } else if (is(whitespace, c)) {
             // wait for it...
           } else if (is(nameStart, c)) {
+            if (parser.strict && parser.closedRoot) {
+              strictFail(parser, 'More than one document root')
+              // Get past the end-of-document warning
+              parser.state = S.TEXT
+              return parser
+            }
             parser.state = S.OPEN_TAG
             parser.tagName = c
           } else if (c === '/') {

--- a/test/issue-86.js
+++ b/test/issue-86.js
@@ -77,7 +77,7 @@ require(__dirname).test({
     ],
     [
       'error',
-      'Unexpected end\nLine: 0\nColumn: 20\nChar: '
+      'More than one document root\nLine: 0\nColumn: 20\nChar: f'
     ]
   ],
   strict: true,

--- a/test/single-root.js
+++ b/test/single-root.js
@@ -1,0 +1,129 @@
+// issue-86.js already tests non-strict mode for elements opening after root,
+// and for non-whitespace characters after the root.
+
+require(__dirname).test({
+  xml: '<root/><bar/>',
+  expect: [
+    [
+      'opentagstart',
+      {
+        name: 'root',
+        attributes: {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'root',
+        attributes: {},
+        isSelfClosing: true
+      }
+    ],
+    [
+      'closetag',
+      'root'
+    ],
+    [
+      'error',
+      'More than one document root\nLine: 0\nColumn: 9\nChar: b'
+    ]
+  ],
+  strict: true,
+  opt: {}
+})
+
+require(__dirname).test({
+  xml: '<root/><!-- ok -->',
+  expect: [
+    [
+      'opentagstart',
+      {
+        name: 'root',
+        attributes: {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'root',
+        attributes: {},
+        isSelfClosing: true
+      }
+    ],
+    [
+      'closetag',
+      'root'
+    ],
+    [
+      'comment',
+      ' ok '
+    ]
+  ],
+  strict: true,
+  opt: {}
+})
+
+require(__dirname).test({
+  xml: '<root/><?ok foo?>',
+  expect: [
+    [
+      'opentagstart',
+      {
+        name: 'root',
+        attributes: {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'root',
+        attributes: {},
+        isSelfClosing: true
+      }
+    ],
+    [
+      'closetag',
+      'root'
+    ],
+    [
+      'processinginstruction',
+      {
+        name: 'ok',
+        body: 'foo'
+      }
+    ]
+  ],
+  strict: true,
+  opt: {}
+})
+
+require(__dirname).test({
+  xml: '<root/>\n\n',
+  expect: [
+    [
+      'opentagstart',
+      {
+        name: 'root',
+        attributes: {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'root',
+        attributes: {},
+        isSelfClosing: true
+      }
+    ],
+    [
+      'closetag',
+      'root'
+    ],
+    [
+      'text',
+      '\n\n'
+    ]
+  ],
+  strict: true,
+  opt: {}
+})


### PR DESCRIPTION
In non-strict mode, I chose not to change the behavior already tested for in test/issue-86.js.  I will be happy to adjust that if so desired.