### PR TITLE
Parse result of custom entity replacement

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1495,7 +1495,15 @@
           }
 
           if (c === ';') {
-            parser[buffer] += parseEntity(parser)
+            var parsedEntity = parseEntity(parser)
+
+            // Custom entities can contain tags, so we potentially need to parse the result
+            if (parser.state === S.TEXT_ENTITY && !sax.ENTITIES[parser.entity] && parsedEntity !== '&' + parser.entity + ';') {
+              chunk = chunk.slice(0, i) + parsedEntity + chunk.slice(i)
+            } else {
+              parser[buffer] += parsedEntity
+            }
+
             parser.entity = ''
             parser.state = returnState
           } else if (is(parser.entity.length ? entityBody : entityStart, c)) {

--- a/test/entity-tags.js
+++ b/test/entity-tags.js
@@ -1,0 +1,15 @@
+require(__dirname).test({
+  xml: 'testing &custom; hi &unknown;',
+  entities: {
+    custom: '<foo bar="baz">hi</foo>'
+  },
+  expect: [
+    ['text', 'testing '],
+    ['opentagstart', {'name': 'FOO', attributes: {}}],
+    ['attribute', {name: 'BAR', value: 'baz'}],
+    ['opentag', {'name': 'FOO', attributes: {BAR: 'baz'}, isSelfClosing: false}],
+    ['text', 'hi'],
+    ['closetag', 'FOO'],
+    ['text', ' hi &unknown;']
+  ]
+})

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,11 @@ exports.sax = sax
 exports.test = function test (options) {
   var xml = options.xml
   var parser = sax.parser(options.strict, options.opt)
+  if (options.entities) {
+    for (var key in options.entities) {
+      parser.ENTITIES[key] = options.entities[key]
+    }
+  }
   var expect = options.expect
   var e = 0
   sax.EVENTS.forEach(function (ev) {


### PR DESCRIPTION
Fix for #199. If a custom entity is parsed, the result is inserted into the string to be parsed next. That way if an entity is defined with tags in it, it is parsed as XML as if it were inline and not just emitted as a string.
