### PR TITLE
Performance improvement, typically 25%, by splitting internal 'is' function

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -307,12 +307,16 @@
     }, {})
   }
 
-  function isRegExp (c) {
-    return Object.prototype.toString.call(c) === '[object RegExp]'
+  function isMatch (regex, c) {
+    return regex.test(c)
   }
 
   function is (charclass, c) {
-    return isRegExp(charclass) ? !!c.match(charclass) : charclass[c]
+    return charclass[c]
+  }
+
+  function notMatch (regex, c) {
+    return !isMatch(regex, c)
   }
 
   function not (charclass, c) {
@@ -1080,7 +1084,7 @@
             parser.sgmlDecl = ''
           } else if (is(whitespace, c)) {
             // wait for it...
-          } else if (is(nameStart, c)) {
+          } else if (isMatch(nameStart, c)) {
             parser.state = S.OPEN_TAG
             parser.tagName = c
           } else if (c === '/') {
@@ -1283,7 +1287,7 @@
           continue
 
         case S.OPEN_TAG:
-          if (is(nameBody, c)) {
+          if (isMatch(nameBody, c)) {
             parser.tagName += c
           } else {
             newTag(parser)
@@ -1318,7 +1322,7 @@
             openTag(parser)
           } else if (c === '/') {
             parser.state = S.OPEN_TAG_SLASH
-          } else if (is(nameStart, c)) {
+          } else if (isMatch(nameStart, c)) {
             parser.attribName = c
             parser.attribValue = ''
             parser.state = S.ATTRIB_NAME
@@ -1337,7 +1341,7 @@
             openTag(parser)
           } else if (is(whitespace, c)) {
             parser.state = S.ATTRIB_NAME_SAW_WHITE
-          } else if (is(nameBody, c)) {
+          } else if (isMatch(nameBody, c)) {
             parser.attribName += c
           } else {
             strictFail(parser, 'Invalid attribute name')
@@ -1360,7 +1364,7 @@
             parser.attribName = ''
             if (c === '>') {
               openTag(parser)
-            } else if (is(nameStart, c)) {
+            } else if (isMatch(nameStart, c)) {
               parser.attribName = c
               parser.state = S.ATTRIB_NAME
             } else {
@@ -1404,7 +1408,7 @@
             openTag(parser)
           } else if (c === '/') {
             parser.state = S.OPEN_TAG_SLASH
-          } else if (is(nameStart, c)) {
+          } else if (isMatch(nameStart, c)) {
             strictFail(parser, 'No whitespace between attributes')
             parser.attribName = c
             parser.attribValue = ''
@@ -1435,7 +1439,7 @@
           if (!parser.tagName) {
             if (is(whitespace, c)) {
               continue
-            } else if (not(nameStart, c)) {
+            } else if (notMatch(nameStart, c)) {
               if (parser.script) {
                 parser.script += '</' + c
                 parser.state = S.SCRIPT
@@ -1447,7 +1451,7 @@
             }
           } else if (c === '>') {
             closeTag(parser)
-          } else if (is(nameBody, c)) {
+          } else if (isMatch(nameBody, c)) {
             parser.tagName += c
           } else if (parser.script) {
             parser.script += '</' + parser.tagName
@@ -1498,7 +1502,7 @@
             parser[buffer] += parseEntity(parser)
             parser.entity = ''
             parser.state = returnState
-          } else if (is(parser.entity.length ? entityBody : entityStart, c)) {
+          } else if (isMatch(parser.entity.length ? entityBody : entityStart, c)) {
             parser.entity += c
           } else {
             strictFail(parser, 'Invalid character in entity name')


### PR DESCRIPTION
Hello, at my current place of work we’ve been processing relatively large XML documents with `expat` but recently started trialling the use of the object-building `xml2js`, which depends upon this module.

Performance was of concern, so I carried out some V8 profiling and discovered a few hot spots:

```
 [C++]:
   ticks  total  nonlib   name
    121    5.0%    5.0%  int v8::internal::BinarySearch<(v8::internal::SearchMode)1, v8::internal::DescriptorArray>(v8::internal::DescriptorArray*, v8::internal::Name*, int, int*)
     98    4.0%    4.1%  v8::internal::Object::ObjectProtoToString(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>)

 [C++ entry points]:
   ticks    cpp   total   name
    566   41.0%   23.2%  v8::internal::Builtin_ObjectProtoToString(int, v8::internal::Object**, v8::internal::Isolate*)
    178   12.9%    7.3%  v8::internal::Runtime_StringEqual(int, v8::internal::Object**, v8::internal::Isolate*)
    122    8.8%    5.0%  v8::internal::Runtime_KeyedLoadIC_Miss(int, v8::internal::Object**, v8::internal::Isolate*)
```

This module currently has an internal `is` function that accepts either a RegExp or an Object. Much of the time is spent determining what data type has been passed to it by calling `Object.prototype.toString`.

Luckily the type is already known at all the call sites for this function, so this PR splits the `is` function into an Object version and a RegExp version. The RegExp version also uses the short-circuiting `regex.test` rather than a full `regex.match`.

Profiling with the changes in this PR reveals the hot spots are gone:

```
[C++]:
   ticks  total  nonlib   name
     63    4.0%    4.0%  node::ContextifyScript::New(v8::FunctionCallbackInfo<v8::Value> const&)

[C++ entry points]:
   ticks    cpp   total   name
     83   12.3%    5.2%  v8::internal::Runtime_KeyedLoadIC_Miss(int, v8::internal::Object**, v8::internal::Isolate*)
```

Performance testing with real world XML of various orders of magnitude with a Node v6 runtime suggests performance gains are in the 25-40% region, possibly slightly more for even larger documents or longer running processes.

| XML size/MB | Current time/ms | New time/ms | Speed-up |
| - | - | - | - |
| 0.1 | 61 | 45 | 25% |
| 1 | 323 | 210 | 35% |
| 10 | 2550 | 1535 | 40% |

The contribution guide asks for tests but I'm unsure of the best way to further test this change beyond the existing and already-extensive unit test suite; guidance welcome here.

Thank you for continuing to maintain this highly-depended upon module.