### PR TITLE
added the option to choose casing for loose mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .*.swp
 node_modules/*
 nyc_output/

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ Settings supported:
 * `trim` - Boolean. Whether or not to trim text and comment nodes.
 * `normalize` - Boolean. If true, then turn any whitespace into a single
   space.
-* `lowercase` - Boolean. If true, then lowercase tag names and attribute names
-  in loose mode, rather than uppercasing them.
+* `looseCasing` - String (`'lower'`/`'upper'`). In loose mode, the casing of tag names and
+  attributes will be lower/upper cased or left alone if `looseCasing` is falsy.
+  If this property is set (including `null`), the deprecated `lowercase` and `lowercasetags`
+  are overridden.
 * `xmlns` - Boolean. If true, then namespaces are supported.
 * `position` - Boolean. If false, then don't track line/col/position.
 * `strictEntities` - Boolean. If true, only parse [predefined XML
@@ -174,8 +176,8 @@ but before any attributes are encountered.  Argument: object with a
 same object that will later be emitted in the `opentag` event.
 
 `opentag` - An opening tag. Argument: object with `name` and `attributes`.
-In non-strict mode, tag names are uppercased, unless the `lowercase`
-option is set.  If the `xmlns` option is set, then it will contain
+In non-strict mode, tag names will be uppercased or lower cased if `looseCasing`
+option is set on `lower` or `upper`.  If the `xmlns` option is set, then it will contain
 namespace binding information on the `ns` member, and will have a
 `local`, `prefix`, and `uri` member.
 
@@ -185,8 +187,8 @@ self-closing tags will have `closeTag` emitted immediately after `openTag`.
 Argument: tag name.
 
 `attribute` - An attribute node.  Argument: object with `name` and `value`.
-In non-strict mode, attribute names are uppercased, unless the `lowercase`
-option is set.  If the `xmlns` option is set, it will also contains namespace
+In non-strict mode, attribute names will be uppercased or lower cased if `looseCasing`
+option is set on `lower` or `upper`.  If the `xmlns` option is set, it will also contains namespace
 information.
 
 `comment` - A comment node.  Argument: the string of the comment.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Pass the following arguments to the parser function.  All are optional.
 
 `strict` - Boolean. Whether or not to be a jerk. Default: `false`.
 
-`opt` - Object bag of settings regarding string formatting.  All default to `false`.
+`opt` - Object bag of settings regarding string formatting.  All default to `false`, `looseCasing` default to `upper`.
 
 Settings supported:
 
@@ -101,8 +101,7 @@ Settings supported:
   space.
 * `looseCasing` - String (`'lower'`/`'upper'`). In loose mode, the casing of tag names and
   attributes will be lower/upper cased or left alone if `looseCasing` is falsy.
-  If this property is set (including `null`), the deprecated `lowercase` and `lowercasetags`
-  are overridden.
+  The deprecated `lowercase` and `lowercasetags` overrides this property if set.
 * `xmlns` - Boolean. If true, then namespaces are supported.
 * `position` - Boolean. If false, then don't track line/col/position.
 * `strictEntities` - Boolean. If true, only parse [predefined XML

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -57,13 +57,18 @@
     parser.q = parser.c = ''
     parser.bufferCheckPosition = sax.MAX_BUFFER_LENGTH
     parser.opt = opt || {}
-    parser.opt.lowercase = parser.opt.lowercase || parser.opt.lowercasetags
-    if(parser.opt.hasOwnProperty('looseCasing')){
-      parser.looseCase = looseCaseMapping[parser.opt.looseCasing]
+
+    if(!parser.opt.hasOwnProperty('looseCasing')){
+      parser.opt.looseCasing = 'upper'
     }
-    else{
-      parser.looseCase = parser.opt.lowercase ? 'toLowerCase' : 'toUpperCase'
+    parser.looseCase = looseCaseMapping[parser.opt.looseCasing]
+
+    // backwards support for deprecated "lowercase" and "lowercasetags" options
+    if(parser.opt.hasOwnProperty('lowercase') || parser.opt.hasOwnProperty('lowercasetags')){
+      parser.looseCase = (parser.opt.lowercase || parser.opt.lowercasetags) ?
+        'toLowerCase' : 'toUpperCase'
     }
+
     parser.tags = []
     parser.closed = parser.closedRoot = parser.sawRoot = false
     parser.tag = parser.error = null

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -42,6 +42,11 @@
     'closenamespace'
   ]
 
+  var looseCaseMapping = {
+    lower: 'toLowerCase',
+    upper: 'toUpperCase'
+  }
+
   function SAXParser (strict, opt) {
     if (!(this instanceof SAXParser)) {
       return new SAXParser(strict, opt)
@@ -53,7 +58,12 @@
     parser.bufferCheckPosition = sax.MAX_BUFFER_LENGTH
     parser.opt = opt || {}
     parser.opt.lowercase = parser.opt.lowercase || parser.opt.lowercasetags
-    parser.looseCase = parser.opt.lowercase ? 'toLowerCase' : 'toUpperCase'
+    if(parser.opt.hasOwnProperty('looseCasing')){
+      parser.looseCase = looseCaseMapping[parser.opt.looseCasing]
+    }
+    else{
+      parser.looseCase = parser.opt.lowercase ? 'toLowerCase' : 'toUpperCase'
+    }
     parser.tags = []
     parser.closed = parser.closedRoot = parser.sawRoot = false
     parser.tag = parser.error = null
@@ -695,7 +705,9 @@
   }
 
   function newTag (parser) {
-    if (!parser.strict) parser.tagName = parser.tagName[parser.looseCase]()
+    if (!parser.strict && parser.looseCase) {
+      parser.tagName = parser.tagName[parser.looseCase]()
+    }
     var parent = parser.tags[parser.tags.length - 1] || parser
     var tag = parser.tag = { name: parser.tagName, attributes: {} }
 
@@ -723,7 +735,7 @@
   }
 
   function attrib (parser) {
-    if (!parser.strict) {
+    if (!parser.strict && parser.looseCase) {
       parser.attribName = parser.attribName[parser.looseCase]()
     }
 
@@ -876,7 +888,7 @@
     // <a><b></c></b></a> will close everything, otherwise.
     var t = parser.tags.length
     var tagName = parser.tagName
-    if (!parser.strict) {
+    if (!parser.strict && parser.looseCase) {
       tagName = tagName[parser.looseCase]()
     }
     var closeTo = tagName

--- a/test/casing.js
+++ b/test/casing.js
@@ -1,0 +1,83 @@
+// test lower looseCasing
+require(__dirname).test({
+  xml: '<span class="test" hello="world"></span>',
+  expect: [
+    [ 'opentagstart', {
+      name: 'span',
+      attributes: {}
+    } ],
+    [ 'attribute', { name: 'class', value: 'test' } ],
+    [ 'attribute', { name: 'hello', value: 'world' } ],
+    [ 'opentag', {
+      name: 'span',
+      attributes: { class: 'test', hello: 'world' },
+      isSelfClosing: false
+    } ],
+    [ 'closetag', 'span' ]
+  ],
+  strict: false,
+  opt: {looseCasing: 'lower'}
+})
+
+// test upper looseCasing
+require(__dirname).test({
+  xml: '<span class="test" hello="world"></span>',
+  expect: [
+    [ 'opentagstart', {
+      name: 'SPAN',
+      attributes: {}
+    } ],
+    [ 'attribute', { name: 'CLASS', value: 'test' } ],
+    [ 'attribute', { name: 'HELLO', value: 'world' } ],
+    [ 'opentag', {
+      name: 'SPAN',
+      attributes: { CLASS: 'test', HELLO: 'world' },
+      isSelfClosing: false
+    } ],
+    [ 'closetag', 'SPAN' ]
+  ],
+  strict: false,
+  opt: {looseCasing: 'upper'}
+})
+
+// test no looseCasing
+require(__dirname).test({
+  xml: '<span className="test" hello="world"></span>',
+  expect: [
+    [ 'opentagstart', {
+      name: 'span',
+      attributes: {}
+    } ],
+    [ 'attribute', { name: 'className', value: 'test' } ],
+    [ 'attribute', { name: 'hello', value: 'world' } ],
+    [ 'opentag', {
+      name: 'span',
+      attributes: { className: 'test', hello: 'world' },
+      isSelfClosing: false
+    } ],
+    [ 'closetag', 'span' ]
+  ],
+  strict: false,
+  opt: {looseCasing: null}
+})
+
+// make sure looseCasing overrides the lowercase option
+require(__dirname).test({
+  xml: '<span className="test" hello="world"></span>',
+  expect: [
+    [ 'opentagstart', {
+      name: 'span',
+      attributes: {}
+    } ],
+    [ 'attribute', { name: 'className', value: 'test' } ],
+    [ 'attribute', { name: 'hello', value: 'world' } ],
+    [ 'opentag', {
+      name: 'span',
+      attributes: { className: 'test', hello: 'world' },
+      isSelfClosing: false
+    } ],
+    [ 'closetag', 'span' ]
+  ],
+  strict: false,
+  opt: {lowercase: true, looseCasing: null}
+})

--- a/test/casing.js
+++ b/test/casing.js
@@ -61,7 +61,7 @@ require(__dirname).test({
   opt: {looseCasing: null}
 })
 
-// make sure looseCasing overrides the lowercase option
+// make sure deprecated lowercase overrides the looseCasing null option
 require(__dirname).test({
   xml: '<span className="test" hello="world"></span>',
   expect: [
@@ -69,15 +69,58 @@ require(__dirname).test({
       name: 'span',
       attributes: {}
     } ],
-    [ 'attribute', { name: 'className', value: 'test' } ],
+    [ 'attribute', { name: 'classname', value: 'test' } ],
     [ 'attribute', { name: 'hello', value: 'world' } ],
     [ 'opentag', {
       name: 'span',
-      attributes: { className: 'test', hello: 'world' },
+      attributes: { classname: 'test', hello: 'world' },
       isSelfClosing: false
     } ],
     [ 'closetag', 'span' ]
   ],
   strict: false,
   opt: {lowercase: true, looseCasing: null}
+})
+
+// make sure deprecated lowercase overrides the looseCasing upper option
+require(__dirname).test({
+  xml: '<span className="test" hello="world"></span>',
+  expect: [
+    [ 'opentagstart', {
+      name: 'span',
+      attributes: {}
+    } ],
+    [ 'attribute', { name: 'classname', value: 'test' } ],
+    [ 'attribute', { name: 'hello', value: 'world' } ],
+    [ 'opentag', {
+      name: 'span',
+      attributes: { classname: 'test', hello: 'world' },
+      isSelfClosing: false
+    } ],
+    [ 'closetag', 'span' ]
+  ],
+  strict: false,
+  opt: {lowercase: true, looseCasing: 'upper'}
+})
+
+
+// make sure deprecated lowercasetags overrides the looseCasing upper option
+require(__dirname).test({
+  xml: '<span className="test" hello="world"></span>',
+  expect: [
+    [ 'opentagstart', {
+      name: 'span',
+      attributes: {}
+    } ],
+    [ 'attribute', { name: 'classname', value: 'test' } ],
+    [ 'attribute', { name: 'hello', value: 'world' } ],
+    [ 'opentag', {
+      name: 'span',
+      attributes: { classname: 'test', hello: 'world' },
+      isSelfClosing: false
+    } ],
+    [ 'closetag', 'span' ]
+  ],
+  strict: false,
+  opt: {lowercasetags: true, looseCasing: 'upper'}
 })


### PR DESCRIPTION
this fixes https://github.com/isaacs/sax-js/issues/206.

Instead of the confusing "UpperCase" in not strict mode unless "lowercase" is set,
I added the "looseCasing" property to support "upper/lower/unchanged" casing.

looseCasing defaults to "upper" so the default behavior didn't change.

backwards support- setting "lowercase" / "lowercasetags" overrides this property.

tests- added tests for the looseCasing options and also backwards support test