### PR TITLE
expose scriptTags option

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -63,6 +63,10 @@
     parser.strictEntities = parser.opt.strictEntities
     parser.ENTITIES = parser.strictEntities ? Object.create(sax.XML_ENTITIES) : Object.create(sax.ENTITIES)
     parser.attribList = []
+    var scriptTags = parser.scriptTags = {};
+    (parser.opt.scriptTags || ['script']).forEach(function (tag) {
+      scriptTags[tag] = true
+    })
 
     // namespaces form a prototype chain.
     // it always points at the current tag,
@@ -825,7 +829,7 @@
     emitNode(parser, 'onopentag', parser.tag)
     if (!selfClosing) {
       // special case for <script> in non-strict mode.
-      if (!parser.noscript && parser.tagName.toLowerCase() === 'script') {
+      if (!parser.noscript && parser.scriptTags.hasOwnProperty(parser.tagName.toLowerCase())) {
         parser.state = S.SCRIPT
       } else {
         parser.state = S.TEXT
@@ -846,7 +850,7 @@
     }
 
     if (parser.script) {
-      if (parser.tagName !== 'script') {
+      if (!parser.scriptTags.hasOwnProperty(parser.tagName)) {
         parser.script += '</' + parser.tagName + '>'
         parser.tagName = ''
         parser.state = S.SCRIPT

--- a/test/script.js
+++ b/test/script.js
@@ -64,3 +64,56 @@ require(__dirname).test({
     ]
   ]
 })
+
+require(__dirname).test({
+  xml: '<div><style><foo></foo></style></div>',
+  expect: [
+    [
+      'opentagstart',
+      {
+        'name': 'DIV',
+        'attributes': {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        'name': 'DIV',
+        'attributes': {},
+        'isSelfClosing': false
+      }
+    ],
+    [
+      'opentagstart',
+      {
+        'name': 'STYLE',
+        'attributes': {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        'name': 'STYLE',
+        'attributes': {},
+        'isSelfClosing': false
+      }
+    ],
+    [
+      'script',
+      '<foo></foo>'
+    ],
+    [
+      'closetag',
+      'STYLE'
+    ],
+    [
+      'closetag',
+      'DIV'
+    ]
+  ],
+  opt: {
+    scriptTags: [
+      'style'
+    ]
+  }
+})


### PR DESCRIPTION
This feature makes parsing problematic tags similar to `script`, such as `style`, an option.