### PR TITLE
adds installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ be my guest.
 Unknown entities will fail in strict mode, and in loose mode, will pass
 through unmolested.
 
+## Installation
+
+```
+npm install --save sax
+```
+
 ## Usage
 
 ```javascript


### PR DESCRIPTION
The mismatch between the github repo name and the npm name adds a little friction that's easily solved by an installation section in the README. 

Thanks for the lib, its just what i need :)