### PR TITLE
Add location properties on error object

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -647,8 +647,13 @@
       er += '\nLine: ' + parser.line +
         '\nColumn: ' + parser.column +
         '\nChar: ' + parser.c
+      er = new Error(er)
+      er.line = parser.line
+      er.column = parser.column
+      er.char = parser.c
+    } else {
+      er = new Error(er)
     }
-    er = new Error(er)
     parser.error = er
     emit(parser, 'onerror', er)
     return parser

--- a/test/error-location-properties.js
+++ b/test/error-location-properties.js
@@ -1,0 +1,17 @@
+var sax = require('../lib/sax')
+var t = require('tap')
+
+t.plan(4)
+
+var parser = sax.parser(true)
+
+parser.onerror = function (error) {
+  t.equal(error.message, 'Unexpected close tag\nLine: 2\nColumn: 7\nChar: >')
+  t.equal(error.line, 2)
+  t.equal(error.column, 7)
+  t.equal(error.char, '>')
+  parser.resume()
+}
+
+parser.write('<root>\n<p>Hello, world\n</root>').close();
+

--- a/test/error-location-properties.js
+++ b/test/error-location-properties.js
@@ -13,5 +13,5 @@ parser.onerror = function (error) {
   parser.resume()
 }
 
-parser.write('<root>\n<p>Hello, world\n</root>').close();
+parser.write('<root>\n<p>Hello, world\n</root>').close()
 


### PR DESCRIPTION
Implements #220 

When an error is thrown, the line, column and char are put into the error message but the values aren't accessible. This pull request adds the location as a set of properties on the error object:

```js
er.line = parser.line
er.column = parser.column
er.char = parser.c
```

When handling the error, this makes the location information usable.

```js
parser.onerror = function(error) {
  console.error('An error occured on line ' + error.line);
}
```

Added a test.