### PR TITLE
In strict mode, report an error on empty processing instructions.

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1257,10 +1257,14 @@
 
         case S.PROC_INST_ENDING:
           if (c === '>') {
-            emitNode(parser, 'onprocessinginstruction', {
-              name: parser.procInstName,
-              body: parser.procInstBody
-            })
+            if (parser.procInstName === '') {
+              strictFail(parser, 'Processing instruction without a name')
+            } else {
+              emitNode(parser, 'onprocessinginstruction', {
+                name: parser.procInstName,
+                body: parser.procInstBody
+              })
+            }
             parser.procInstName = parser.procInstBody = ''
             parser.state = S.TEXT
           } else {

--- a/test/processing-instruction.js
+++ b/test/processing-instruction.js
@@ -1,0 +1,38 @@
+require(__dirname).test({
+  xml: '<?name body?><xml>body</xml>',
+  expect: [
+    [ 'processinginstruction', { name: 'name', body: 'body' } ],
+    [ 'opentagstart', { name: 'xml', attributes: {} } ],
+    [ 'opentag', { name: 'xml', attributes: {}, isSelfClosing: false } ],
+    [ 'text', 'body' ],
+    [ 'closetag', 'xml' ]
+  ],
+  strict: true
+})
+
+require(__dirname).test({
+  xml: '<?name?><xml>body</xml>',
+  expect: [
+    [ 'processinginstruction', { name: 'name', body: '' } ],
+    [ 'opentagstart', { name: 'xml', attributes: {} } ],
+    [ 'opentag', { name: 'xml', attributes: {}, isSelfClosing: false } ],
+    [ 'text', 'body' ],
+    [ 'closetag', 'xml' ]
+  ],
+  strict: true
+})
+
+require(__dirname).test({
+  xml: '<??><xml>body</xml>',
+  expect: [
+    [
+      'error',
+      'Processing instruction without a name\nLine: 0\nColumn: 4\nChar: >'
+    ],
+    [ 'opentagstart', { name: 'xml', attributes: {} } ],
+    [ 'opentag', { name: 'xml', attributes: {}, isSelfClosing: false } ],
+    [ 'text', 'body' ],
+    [ 'closetag', 'xml' ]
+  ],
+  strict: true
+})


### PR DESCRIPTION
Empty processing instructions (like this: `<??>`) are not well-formed, and thus not XML. This commit makes sax report an error when used in strict mode.