### PR TITLE
Issue 262: Notify the virtual closing of tag

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -621,13 +621,13 @@
   // shorthand
   S = sax.STATE
 
-  function emit (parser, event, data) {
-    parser[event] && parser[event](data)
+  function emit (parser, event, ...data) {
+    parser[event] && parser[event](...data)
   }
 
-  function emitNode (parser, nodeType, data) {
+  function emitNode (parser, nodeType, ...data) {
     if (parser.textNode) closeText(parser)
-    emit(parser, nodeType, data)
+    emit(parser, nodeType, ...data)
   }
 
   function closeText (parser) {
@@ -887,7 +887,7 @@
     while (s-- > t) {
       var tag = parser.tag = parser.tags.pop()
       parser.tagName = parser.tag.name
-      emitNode(parser, 'onclosetag', parser.tagName)
+      emitNode(parser, 'onclosetag', parser.tagName, s > t)
 
       var x = {}
       for (var i in tag.ns) {

--- a/test/index.js
+++ b/test/index.js
@@ -13,32 +13,34 @@ exports.test = function test (options) {
   var expect = options.expect
   var e = 0
   sax.EVENTS.forEach(function (ev) {
-    parser['on' + ev] = function (n) {
+    parser['on' + ev] = function (...data) {
       if (process.env.DEBUG) {
         console.error({
           expect: expect[e],
-          actual: [ev, n]
+          actual: [ev, ...data]
         })
       }
       if (e >= expect.length && (ev === 'end' || ev === 'ready')) {
         return
       }
       t.ok(e < expect.length, 'no unexpected events')
-
+      
       if (!expect[e]) {
-        t.fail('did not expect this event', {
+        t.fail('did not expect the event ' + ev, {
           event: ev,
           expect: expect,
-          data: n
+          data: data
         })
         return
       }
 
       t.equal(ev, expect[e][0])
       if (ev === 'error') {
-        t.equal(n.message, expect[e][1])
+        t.equal(data[0].message, expect[e][1])
       } else {
-        t.same(n, expect[e][1])
+        expect[e].slice(1).forEach((v,i) => {
+          t.same(data[i], v)
+        })
       }
       e++
       if (ev === 'error') {

--- a/test/onclosetag.js
+++ b/test/onclosetag.js
@@ -1,0 +1,177 @@
+require(__dirname).test({
+    xml: "<root length='12345'><span></root>",
+    expect: [
+      [
+        'opentagstart',
+        {
+          name: 'root',
+          attributes: {}
+        }
+      ],
+      [
+        'attribute',
+        {
+          name: 'length',
+          value: '12345'
+        }
+      ],
+      [
+        'opentag',
+        {
+          name: 'root',
+          attributes: {
+            length: '12345'
+          },
+          isSelfClosing: false
+        }
+      ],
+      [
+        'opentagstart',
+        {
+          name: 'span',
+          attributes: {}
+        }
+      ],
+      [
+        'opentag',
+        {
+          name: 'span',
+          attributes: {},
+          isSelfClosing: false
+        }
+      ],
+      [
+        'closetag',
+        'span',
+        true
+      ],
+      [
+        'closetag',
+        'root'
+      ]
+    ],
+    strict: false,
+    opt : {
+        lowercase:true,
+        xmlns:false
+    }
+  })
+
+
+require(__dirname).test({
+  xml: "<root length='12345'><span></span></root>",
+  expect: [
+    [
+      'opentagstart',
+      {
+        name: 'root',
+        attributes: {}
+      }
+    ],
+    [
+      'attribute',
+      {
+        name: 'length',
+        value: '12345'
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'root',
+        attributes: {
+          length: '12345'
+        },
+        isSelfClosing: false
+      }
+    ],
+    [
+      'opentagstart',
+      {
+        name: 'span',
+        attributes: {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'span',
+        attributes: {},
+        isSelfClosing: false
+      }
+    ],
+    [
+      'closetag',
+      'span',
+      false
+    ],
+    [
+      'closetag',
+      'root'
+    ]
+  ],
+  strict: false,
+  opt : {
+      lowercase:true,
+      xmlns:false
+  }
+})
+
+require(__dirname).test({
+  xml: "<root length='12345'><span/></root>",
+  expect: [
+    [
+      'opentagstart',
+      {
+        name: 'root',
+        attributes: {}
+      }
+    ],
+    [
+      'attribute',
+      {
+        name: 'length',
+        value: '12345'
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'root',
+        attributes: {
+          length: '12345'
+        },
+        isSelfClosing: false
+      }
+    ],
+    [
+      'opentagstart',
+      {
+        name: 'span',
+        attributes: {}
+      }
+    ],
+    [
+      'opentag',
+      {
+        name: 'span',
+        attributes: {},
+        isSelfClosing: true
+      }
+    ],
+    [
+      'closetag',
+      'span',
+      false
+    ],
+    [
+      'closetag',
+      'root'
+    ]
+  ],
+  strict: false,
+  opt : {
+      lowercase:true,
+      xmlns:false
+  }
+})


### PR DESCRIPTION
This PR extends the onclosetag event emiter to also provide a boolean value, as to notify if the closing tag operation was "virtual" (that is, if the closing tag did not exist in the parsed content) or not.

A small set of tests is provided to test if everything is working.

This PR also includes a change on the test function to take in account events the var args modification and allow to optionally test additionnal/optional data provided by event emiter, like the virtual boolean value in this case.

All tests are passing with given modifications.