### PR TITLE
fix: don't throw on comment in dtd

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1090,15 +1090,23 @@
           continue
 
         case S.SGML_DECL:
+          if (parser.sgmlDecl + c === '--') {
+            parser.state = S.COMMENT
+            parser.comment = ''
+            parser.sgmlDecl = ''
+            continue;
+          }
+
+          if (parser.doctype && parser.doctype !== true) {
+            parser.sgmlDecl += c
+            continue;
+          }
+
           if ((parser.sgmlDecl + c).toUpperCase() === CDATA) {
             emitNode(parser, 'onopencdata')
             parser.state = S.CDATA
             parser.sgmlDecl = ''
             parser.cdata = ''
-          } else if (parser.sgmlDecl + c === '--') {
-            parser.state = S.COMMENT
-            parser.comment = ''
-            parser.sgmlDecl = ''
           } else if ((parser.sgmlDecl + c).toUpperCase() === DOCTYPE) {
             parser.state = S.DOCTYPE
             if (parser.doctype || parser.sawRoot) {
@@ -1152,10 +1160,14 @@
           continue
 
         case S.DOCTYPE_DTD:
-          parser.doctype += c
           if (c === ']') {
+            parser.doctype += c
             parser.state = S.DOCTYPE
+          } else if (c === '<') {
+            parser.state = S.OPEN_WAKA
+            parser.startTagPosition = parser.position
           } else if (isQuote(c)) {
+            parser.doctype += c
             parser.state = S.DOCTYPE_DTD_QUOTED
             parser.q = c
           }
@@ -1198,6 +1210,8 @@
             // which is a comment of " blah -- bloo "
             parser.comment += '--' + c
             parser.state = S.COMMENT
+          } else if (parser.doctype && parser.doctype !== true) {
+            parser.state = S.DOCTYPE_DTD
           } else {
             parser.state = S.TEXT
           }

--- a/test/doctype-with-comment.js
+++ b/test/doctype-with-comment.js
@@ -1,0 +1,10 @@
+require(__dirname).test({
+  xml: '<!DOCTYPE svg [<!--comment with \' and ] symbols-->]><svg></svg>',
+  expect: [
+    [ 'comment', 'comment with \' and ] symbols' ],
+    [ 'doctype', ' svg []' ],
+    [ 'opentagstart', { name: 'SVG', attributes: {} } ],
+    [ 'opentag', { name: 'SVG', attributes: {}, isSelfClosing: false } ],
+    [ 'closetag', 'SVG' ],
+  ]
+})


### PR DESCRIPTION
Makes the minimum change to allow comments in Doctype declarations, without adding additional support for parsing Doctype entities.

As sax was not checking for comments before, it would interpret `'` or `]` as XML and falsely treat them as real quotes or closing tags despite residing in an XML comment.

I don't think compatibility is a major concern for this PR, as the previous behavior was to throw an exception, so XML files that were affected by this weren't supported to begin with.

## Regression Tests

I ran the regression test script from https://github.com/isaacs/sax-js/pull/266 on this PR, and can confirm it passes. 👍🏽

## Related

* Closes https://github.com/isaacs/sax-js/issues/236
* Closes https://github.com/isaacs/sax-js/pull/235 - Only adds a test case but no fix.
* Resolves downstream https://github.com/svg/svgo/issues/879