### PR TITLE
feat: add explicit option for unquoted attribute values

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Settings supported:
 * `strictEntities` - Boolean. If true, only parse [predefined XML
   entities](http://www.w3.org/TR/REC-xml/#sec-predefined-ent)
   (`&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;`)
+* `unquotedAttributeValues` - Boolean. If true, then unquoted
+  attribute values are allowed. Defaults to `false` when `strict`
+  is true, `true` otherwise.
 
 ## Methods
 

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -71,6 +71,12 @@
       parser.ns = Object.create(rootNS)
     }
 
+    // disallow unquoted attribute values if not otherwise configured
+    // and strict mode is true
+    if (parser.opt.unquotedAttributeValues === undefined) {
+      parser.opt.unquotedAttributeValues = !strict;
+    }
+
     // mostly just for error reporting
     parser.trackPosition = parser.opt.position !== false
     if (parser.trackPosition) {
@@ -1379,7 +1385,9 @@
             parser.q = c
             parser.state = S.ATTRIB_VALUE_QUOTED
           } else {
-            strictFail(parser, 'Unquoted attribute value')
+            if (!parser.opt.unquotedAttributeValues) {
+              error(parser, 'Unquoted attribute value')
+            }
             parser.state = S.ATTRIB_VALUE_UNQUOTED
             parser.attribValue = c
           }

--- a/test/unquoted-attribute-values.js
+++ b/test/unquoted-attribute-values.js
@@ -1,0 +1,71 @@
+// strict: true
+require(__dirname).test({
+  xml: '<svg width=20px height=20px />',
+  expect: [
+    ['opentagstart', { name: 'svg', attributes: {} }],
+    ['error', 'Unquoted attribute value\nLine: 0\nColumn: 12\nChar: 2'],
+    ['attribute', { name: 'width', value: '20px' }],
+    ['error', 'Unquoted attribute value\nLine: 0\nColumn: 24\nChar: 2'],
+    ['attribute', { name: 'height', value: '20px' }],
+    ['opentag', { name: 'svg', attributes: {
+      width: '20px',
+      height: '20px'
+    }, isSelfClosing: true }],
+    ['closetag', 'svg'],
+  ],
+  strict: true
+})
+
+// strict: false
+require(__dirname).test({
+  xml: '<svg width=20px height=20px />',
+  expect: [
+    ['opentagstart', { name: 'SVG', attributes: {} }],
+    ['attribute', { name: 'WIDTH', value: '20px' }],
+    ['attribute', { name: 'HEIGHT', value: '20px' }],
+    ['opentag', { name: 'SVG', attributes: {
+      WIDTH: '20px',
+      HEIGHT: '20px'
+    }, isSelfClosing: true }],
+    ['closetag', 'SVG'],
+  ],
+  strict: false
+})
+
+// strict: true, opt: { unquotedAttributeValues: true }
+require(__dirname).test({
+  xml: '<svg width=20px height=20px />',
+  expect: [
+    ['opentagstart', { name: 'svg', attributes: {} }],
+    ['attribute', { name: 'width', value: '20px' }],
+    ['attribute', { name: 'height', value: '20px' }],
+    ['opentag', { name: 'svg', attributes: {
+      width: '20px',
+      height: '20px'
+    }, isSelfClosing: true }],
+    ['closetag', 'svg'],
+  ],
+  strict: true,
+  opt: {
+    unquotedAttributeValues: true
+  }
+})
+
+// strict: false, opt: { unquotedAttributeValues: true }
+require(__dirname).test({
+  xml: '<svg width=20px height=20px />',
+  expect: [
+    ['opentagstart', { name: 'SVG', attributes: {} }],
+    ['attribute', { name: 'WIDTH', value: '20px' }],
+    ['attribute', { name: 'HEIGHT', value: '20px' }],
+    ['opentag', { name: 'SVG', attributes: {
+      WIDTH: '20px',
+      HEIGHT: '20px'
+    }, isSelfClosing: true }],
+    ['closetag', 'SVG'],
+  ],
+  strict: false,
+  opt: {
+    unquotedAttributeValues: true
+  }
+})


### PR DESCRIPTION
Would it be alright to make an explicit parser option for handling unquoted attribute values?

This is a backward-compatible change that allows users to specify how they want unquoted attributes handled. If it isn't specified, we fall back to the original behavior by following strict/loose mode.

## Regression Tests

Similarly to #267, I've run the regression test script from #266, and can confirm it passes.

## Alternatives

It looks like downstream projects that want to use strict mode, yet also want to allow unquoted attributes, can safely throw away error events with the message `Unquoted attribute value` if they want this behavior. We could do this instead, if introducing an explicit option upstream is undesirable.

Not certain if that way of handling it could be problematic or have side effects, so I thought this change would be safer.

## Related

* Resolves downstream https://github.com/svg/svgo/issues/678