### PR TITLE
add partial text events

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ this happens *much* more in strict mode. Argument: instance of `Error`.
 
 `text` - Text node. Argument: string of text.
 
+`partialtext` - Intermediate text node, emitted when the parser hasn't completed
+a full `text` node but is still receiving text. Argument: string of text.
+
 `doctype` - The `<!DOCTYPE` declaration. Argument: doctype string.
 
 `processinginstruction` - Stuff like `<?xml foo="blerg" ?>`. Argument:

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -23,6 +23,7 @@
 
   sax.EVENTS = [
     'text',
+    'partialtext',
     'processinginstruction',
     'sgmldeclaration',
     'doctype',
@@ -189,6 +190,10 @@
 
     this._parser.onend = function () {
       me.emit('end')
+    }
+
+    this._parser.onpartialtext = function (text) {
+      me.emit('partialtext', text)
     }
 
     this._parser.onerror = function (er) {
@@ -1039,6 +1044,9 @@
               parser.state = S.TEXT_ENTITY
             } else {
               parser.textNode += c
+              if (c !== '<' && parser.sawRoot && !parser.closedRoot && parser.textNode) {
+                emit(parser, 'onpartialtext', parser.textNode)
+              }
             }
           }
           continue

--- a/test/buffer-overrun.js
+++ b/test/buffer-overrun.js
@@ -17,6 +17,7 @@ require(__dirname).test({
       'attributes': {},
       'isSelfClosing': false
     }],
+    ['partialtext', 'yo'],
     ['text', 'yo'],
     ['closetag', 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ']
   ]

--- a/test/entity-elem.js
+++ b/test/entity-elem.js
@@ -9,6 +9,7 @@ require(__dirname).test({
     ["opentagstart", {name: "A", attributes: {}}],
     ["attribute", {name: 'ATTR', value: "1.2"}],
     ["opentag", {name: "A", attributes: {ATTR: "1.2"}, isSelfClosing: false}],
+    ["partialtext", "2.1"],
     ["text", "2.1"],
     ["opentagstart", {name: "B", attributes: {}}],
     ["attribute", {name: 'ATTR', value: "1.3"}],

--- a/test/entity-recursive.js
+++ b/test/entity-recursive.js
@@ -7,6 +7,7 @@ require(__dirname).test({
   expect: [
     ["opentagstart", {name: "A", attributes: {}}],
     ["opentag", {name: "A", attributes: {}, isSelfClosing: false}],
+    ["partialtext", "2.1"],
     ["text", "2.1"],
     ["closetag", "A"]
   ]

--- a/test/flush.js
+++ b/test/flush.js
@@ -2,6 +2,7 @@ var parser = require(__dirname).test({
   expect: [
     ['opentagstart', {'name': 'T', attributes: {}}],
     ['opentag', {'name': 'T', attributes: {}, isSelfClosing: false}],
+    ['partialtext', 'flush'],
     ['text', 'flush'],
     ['text', 'rest'],
     ['closetag', 'T']

--- a/test/partial-text.js
+++ b/test/partial-text.js
@@ -1,0 +1,25 @@
+var parser = require(__dirname).test({
+    expect: [
+      ['opentagstart', {'name': 'A', attributes: {}}],
+      ['opentag', {'name': 'A', attributes: {}, isSelfClosing: false}],
+      ['opentagstart', {'name': 'B', attributes: {}}],
+      ['opentag', {'name': 'B', attributes: {}, isSelfClosing: false}],
+      ['partialtext', 'foo '],
+      ['partialtext', 'foo bar'],
+      ['text', 'foo bar world'],
+      ['closetag', 'B'],
+      ['opentagstart', {'name': 'C', attributes: {}}],
+      ['opentag', {'name': 'C', attributes: {}, isSelfClosing: false}],
+      ['text', 'full node'],
+      ['closetag', 'C'],
+      ['closetag', 'A']
+    ]
+  })
+  
+  parser.write('<A><B>foo ')
+  parser.write('bar')
+  parser.write(' world</')
+  parser.write('B>')
+  parser.write('<C>full node</C></A>')
+  parser.close()
+  


### PR DESCRIPTION
# Problem
When streaming strings to the parser, it can be useful to receive partial text events to get results before a full `textNode` is returned.

# Use Case
Especially useful when receiving tokens from an LLM and wanting to stream the XML response as it appears.

# Tests
* test passes with the patch
* test fails without the patch