### PR TITLE
Added missing period for consistency and readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Settings supported:
 * `position` - Boolean. If false, then don't track line/col/position.
 * `strictEntities` - Boolean. If true, only parse [predefined XML
   entities](http://www.w3.org/TR/REC-xml/#sec-predefined-ent)
-  (`&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;`)
+  (`&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;`).
 * `unquotedAttributeValues` - Boolean. If true, then unquoted
   attribute values are allowed. Defaults to `false` when `strict`
   is true, `true` otherwise.


### PR DESCRIPTION
Added a missing period in a specific part of the text to maintain consistency across the document. This ensures a uniform writing style, improves readability, and aligns with the formatting used throughout the content.