### PR TITLE
fix: avoid quadratic memory allocation in large CDATA block

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1225,10 +1225,22 @@
           continue
 
         case S.CDATA:
+          var starti = i - 1
+          while (c && c !== ']') {
+            c = charAt(chunk, i++)
+            if (c && parser.trackPosition) {
+              parser.position++
+              if (c === '\n') {
+                parser.line++
+                parser.column = 0
+              } else {
+                parser.column++
+              }
+            }
+          }
+          parser.cdata += chunk.substring(starti, i - 1);
           if (c === ']') {
             parser.state = S.CDATA_ENDING
-          } else {
-            parser.cdata += c
           }
           continue
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/sax.js",
   "license": "BlueOak-1.0.0",
   "scripts": {
-    "test": "tap test/*.js --cov -j4",
+    "test": "tap test/*.js --cov -j4 --jobs 1",
     "preversion": "npm test",
     "postversion": "npm publish",
     "postpublish": "git push origin --all; git push origin --tags"

--- a/test/cdata-mega.js
+++ b/test/cdata-mega.js
@@ -1,0 +1,23 @@
+var process = require('process')
+var t = require('tap')
+var sax = require('../lib/sax')
+
+t.test('cdata-mega', t => {
+  var bytesInMiB = 1024 * 1024
+  var cdataSize = 1 * bytesInMiB
+  var expectedUpperBound = cdataSize * 2;
+  var cdataContent = 'X'.repeat(cdataSize)
+  var xml = '<r><![CDATA[' + cdataContent + ']]></r>'
+
+  var memoryUsageBefore = process.memoryUsage().heapUsed
+
+  var parser = sax.parser()
+  var parsedCData = null
+  parser.oncdata = c => { parsedCData = c }
+  parser.write(xml).close()
+  var memoryUsageDiff = process.memoryUsage().heapUsed - memoryUsageBefore
+  
+  t.equal(parsedCData, cdataContent)
+  t.ok(memoryUsageDiff < expectedUpperBound, 'Expected at most ' + (expectedUpperBound / bytesInMiB) + ' MiB to be allocated, was ' + (memoryUsageDiff / bytesInMiB))
+  t.end()
+})


### PR DESCRIPTION
**Change description:**
Instead of appending to the cdata buffer one character at a time, read entire 'safe' blocks (without ] characters) analogous to the text parsing logic.
An added unit test ensures the memory allocation stays reasonable, but necessitates serial test execution.

**Context:**
We're using sax-js only as a transitive dependency of a transitive dependency - as such, we have no control over how sax-js is invoked. Unfortunately, our dependency invokes sax-js with a singular `write` containing the entire XML. As we have some CDATA blocks dozens of MiB large, this causes the node heap to require a quadratic amount (>5 GiB) of memory and take a (comparatively) long time.
This change applies the same logic used in the text parsing step to parse the CDATA. It would be possible to optimize this further, by checking the characters after an initial `]` to see if the parser needs to abort the optimistic seeking, but I don't believe the performance gains are worth it.