### PR TITLE
feat: Add UTF-16 stream decoding and strict XML encoding validation

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -63,6 +63,7 @@
     clearBuffers(parser)
     parser.q = parser.c = ''
     parser.bufferCheckPosition = sax.MAX_BUFFER_LENGTH
+    parser.encoding = null;
     parser.opt = opt || {}
     parser.opt.lowercase = parser.opt.lowercase || parser.opt.lowercasetags
     parser.looseCase = parser.opt.lowercase ? 'toLowerCase' : 'toUpperCase'
@@ -207,6 +208,39 @@
     return new SAXStream(strict, opt)
   }
 
+  function determineBufferEncoding(data, isEnd) {
+    // BOM-based detection is the most reliable signal when present.
+    if (data.length >= 2) {
+      if (data[0] === 0xff && data[1] === 0xfe) {
+        return 'utf-16le'
+      }
+
+      if (data[0] === 0xfe && data[1] === 0xff) {
+        return 'utf-16be'
+      }
+    }
+
+    if (data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf) {
+      return 'utf8'
+    }
+
+    if (data.length >= 4) {
+      // XML documents without a BOM still start with "<?xml", which is enough
+      // to distinguish UTF-16LE/BE from UTF-8 by looking at the zero bytes.
+      if (data[0] === 0x3c && data[1] === 0x00 && data[2] === 0x3f && data[3] === 0x00) {
+        return 'utf-16le'
+      }
+
+      if (data[0] === 0x00 && data[1] === 0x3c && data[2] === 0x00 && data[3] === 0x3f) {
+        return 'utf-16be'
+      }
+
+      return 'utf8'
+    }
+
+    return isEnd ? 'utf8' : null
+  }
+
   function SAXStream(strict, opt) {
     if (!(this instanceof SAXStream)) {
       return new SAXStream(strict, opt)
@@ -233,7 +267,7 @@
     }
 
     this._decoder = null
-
+    this._decoderBuffer = null
     streamWraps.forEach(function (ev) {
       Object.defineProperty(me, 'on' + ev, {
         get: function () {
@@ -259,16 +293,47 @@
     },
   })
 
+  SAXStream.prototype._decodeBuffer = function (data, isEnd) {
+    if (this._decoderBuffer) {
+      // Keep incomplete leading bytes until we have enough data to infer the
+      // stream encoding, then decode the buffered prefix together with the next chunk.
+      data = Buffer.concat([this._decoderBuffer, data])
+      this._decoderBuffer = null
+    }
+
+    if (!this._decoder) {
+      var encoding = determineBufferEncoding(data, isEnd)
+      if (!encoding) {
+        // A very short first chunk may not contain enough bytes to detect the
+        // encoding yet, so defer decoding until the next write/end call.
+        this._decoderBuffer = data
+        return ''
+      }
+
+      // Store the detected transport encoding so strict mode can compare it
+      // with the optional encoding declared in the XML prolog later on.
+      this._parser.encoding = encoding
+      this._decoder = new TextDecoder(encoding)
+    }
+
+    return this._decoder.decode(data, { stream: !isEnd })
+  }
+
   SAXStream.prototype.write = function (data) {
     if (
       typeof Buffer === 'function' &&
       typeof Buffer.isBuffer === 'function' &&
       Buffer.isBuffer(data)
     ) {
-      if (!this._decoder) {
-        this._decoder = new TextDecoder('utf8')
+      data = this._decodeBuffer(data, false)
+    } else if (this._decoderBuffer) {
+      // Flush any buffered binary prefix before handling a string chunk.
+      // This only matters if the caller mixes Buffer and string writes (used in test).
+      var remaining = this._decodeBuffer(Buffer.alloc(0), true)
+      if (remaining) {
+        this._parser.write(remaining)
+        this.emit('data', remaining)
       }
-      data = this._decoder.decode(data, { stream: true })
     }
 
     this._parser.write(data.toString())
@@ -281,7 +346,13 @@
       this.write(chunk)
     }
     // Flush any remaining decoded data from the TextDecoder
-    if (this._decoder) {
+    if (this._decoderBuffer) {
+      var finalChunk = this._decodeBuffer(Buffer.alloc(0), true)
+      if (finalChunk) {
+        this._parser.write(finalChunk)
+        this.emit('data', finalChunk)
+      }
+    } else if (this._decoder) {
       var remaining = this._decoder.decode()
       if (remaining) {
         this._parser.write(remaining)
@@ -672,6 +743,59 @@
 
   function emit(parser, event, data) {
     parser[event] && parser[event](data)
+  }
+
+  function getDeclaredEncoding(body) {
+    var match = body && body.match(/(?:^|\s)encoding\s*=\s*(['"])([^'"]+)\1/i)
+    return match ? match[2] : null
+  }
+
+  function normalizeEncodingName(encoding) {
+    if (!encoding) {
+      return null
+    }
+
+    return encoding.toLowerCase().replace(/[^a-z0-9]/g, '')
+  }
+
+  function encodingsMatch(detectedEncoding, declaredEncoding) {
+    const detected = normalizeEncodingName(detectedEncoding)
+    const declared = normalizeEncodingName(declaredEncoding)
+
+    if (!detected || !declared) {
+      return true
+    }
+
+    if (declared === 'utf16') {
+      return detected === 'utf16le' || detected === 'utf16be'
+    }
+
+    return detected === declared
+  }
+
+  function validateXmlDeclarationEncoding(parser, data) {
+    if (
+      !parser.strict ||
+      !parser.encoding ||
+      !data ||
+      data.name !== 'xml'
+    ) {
+      return
+    }
+
+    var declaredEncoding = getDeclaredEncoding(data.body)
+    if (
+      declaredEncoding &&
+      !encodingsMatch(parser.encoding, declaredEncoding)
+    ) {
+      strictFail(
+        parser,
+        'XML declaration encoding ' +
+          declaredEncoding +
+          ' does not match detected stream encoding ' +
+          parser.encoding.toUpperCase()
+      )
+    }
   }
 
   function emitNode(parser, nodeType, data) {
@@ -1379,10 +1503,12 @@
 
         case S.PROC_INST_ENDING:
           if (c === '>') {
-            emitNode(parser, 'onprocessinginstruction', {
+            const procInstEndData = {
               name: parser.procInstName,
               body: parser.procInstBody,
-            })
+            }
+            validateXmlDeclarationEncoding(parser, procInstEndData)
+            emitNode(parser, 'onprocessinginstruction', procInstEndData)
             parser.procInstName = parser.procInstBody = ''
             parser.state = S.TEXT
           } else {

--- a/test/utf16-encoding.js
+++ b/test/utf16-encoding.js
@@ -1,0 +1,131 @@
+var t = require('tap')
+var sax = require('../lib/sax')
+
+t.test('parses utf-16 xml streams when the declaration says UTF-16', t => {
+  var stream = sax.createStream(true)
+  var result = {
+    processinginstruction: null,
+    opentagstart: null,
+    opentag: null,
+    text: '',
+    closetag: null,
+    error: null,
+    errorCount: 0,
+  }
+  var xml =
+    '<?xml version="1.0" encoding="UTF-16"?>\n<person>Hi Jérôme</person>'
+  var utf16 = Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(xml, 'utf16le'),
+  ])
+
+  stream.on('processinginstruction', function (node) {
+    result.processinginstruction = node
+  })
+
+  stream.on('opentagstart', function (node) {
+    result.opentagstart = node
+  })
+
+  stream.on('opentag', function (node) {
+    result.opentag = node
+  })
+
+  stream.on('text', function (text) {
+    result.text += text
+  })
+
+  stream.on('closetag', function (name) {
+    result.closetag = name
+  })
+
+  stream.on('error', function (err) {
+    if (!result.error) {
+      result.error = err.message
+    }
+    result.errorCount += 1
+  })
+
+  stream.on('end', function () {
+    t.same(result, {
+      processinginstruction: {
+        name: 'xml',
+        body: 'version="1.0" encoding="UTF-16"',
+      },
+      opentagstart: { name: 'person', attributes: {}, isSelfClosing: false },
+      opentag: { name: 'person', attributes: {}, isSelfClosing: false },
+      text: '\nHi Jérôme',
+      closetag: 'person',
+      error: null,
+      errorCount: 0,
+    })
+    t.end()
+  })
+
+  stream.write(utf16.slice(0, 7))
+  stream.write(utf16.slice(7, 34))
+  stream.end(utf16.slice(34))
+})
+
+t.test('fails in strict mode when declared encoding conflicts with detected utf-16', t => {
+  var stream = sax.createStream(true)
+  var error = null
+  var xml =
+    '<?xml version="1.0" encoding="UTF-8"?>\n<person>Hi Jérôme</person>'
+  var utf16 = Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(xml, 'utf16le'),
+  ])
+
+  stream.on('error', function (err) {
+    if (!error) {
+      error = err.message
+    }
+  })
+
+  stream.on('end', function () {
+    t.equal(
+      error,
+      'XML declaration encoding UTF-8 does not match detected stream encoding UTF-16LE\nLine: 0\nColumn: 38\nChar: >'
+    )
+    t.end()
+  })
+
+  stream.write(utf16.slice(0, 9))
+  stream.end(utf16.slice(9))
+})
+
+t.test('does not fail in non-strict mode when declared encoding conflicts with detected utf-16', t => {
+  var stream = sax.createStream(false)
+  var result = {
+    text: '',
+    error: null,
+  }
+  var xml =
+    '<?xml version="1.0" encoding="UTF-8"?>\n<person>Hi Jérôme</person>'
+  var utf16 = Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(xml, 'utf16le'),
+  ])
+
+  stream.on('text', function (text) {
+    result.text += text
+  })
+
+  stream.on('error', function (err) {
+    if (!result.error) {
+      result.error = err.message
+    }
+  })
+
+  stream.on('end', function () {
+    t.same(result, {
+      text: '\nHi Jérôme',
+      error: null,
+    })
+    t.end()
+  })
+
+  stream.write(utf16.slice(0, 9))
+  stream.end(utf16.slice(9))
+})


### PR DESCRIPTION
Resolve https://github.com/isaacs/sax-js/issues/270

This change adds UTF-16 support for streamed Buffer input in SAXStream.
The stream now detects UTF-16LE/UTF-16BE from the BOM, and also handles UTF-16 XML prologs without BOM by inspecting the first bytes before choosing the decoder.

It also adds strict validation for XML declaration encoding mismatches. In strict mode, the parser now reports an error if the encoding declared in <?xml ... encoding="..."?> does not match the encoding detected from the incoming byte stream. Non-strict mode keeps the previous permissive behavior.

Tests were added to cover successful UTF-16 parsing and the strict/non-strict behavior for conflicting declared encodings.