### PR TITLE
Normalize package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/isaacs/sax-js.git"
+    "url": "git+https://github.com/isaacs/sax-js.git"
   },
   "files": [
     "lib/sax.js",


### PR DESCRIPTION
## Summary

Updates the package repository metadata from the SSH GitHub URL to the equivalent public HTTPS Git URL.

## Why

The published package currently advertises:

```json
"repository": {
  "type": "git",
  "url": "git+ssh://git@github.com/isaacs/sax-js.git"
}
```

That requires SSH-style GitHub access for package metadata consumers. The repository is public, so `git+https://github.com/isaacs/sax-js.git` is friendlier for npm users and automation.

## Validation

- `npm view sax@latest name version repository homepage bugs license --json`
- `node -e "const p=require('./package.json'); if(p.repository.url !== 'git+https://github.com/isaacs/sax-js.git') process.exit(1)"`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Runtime code, package version, dependencies, entry point, files list, homepage, bugs URL, and license are unchanged.