### PR TITLE
fix: reject character references outside the XML Char production in strict mode

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1137,13 +1137,31 @@
       isNaN(num) ||
       numStr.toLowerCase() !== entity ||
       num < 0 ||
-      num > 0x10ffff
+      num > 0x10ffff ||
+      !isXmlChar(num)
     ) {
       strictFail(parser, 'Invalid character entity')
       return '&' + parser.entity + ';'
     }
 
     return String.fromCodePoint(num)
+  }
+
+  // Returns true if `num` is a code point that matches the XML `Char`
+  // production, false otherwise. Character references that resolve to a
+  // character outside this range (e.g. surrogates or restricted control
+  // characters) are not well-formed.
+  // https://www.w3.org/TR/REC-xml/#NT-Char
+  // https://www.w3.org/TR/REC-xml/#wf-Legalchar
+  function isXmlChar(num) {
+    return (
+      num === 0x9 ||
+      num === 0xa ||
+      num === 0xd ||
+      (num >= 0x20 && num <= 0xd7ff) ||
+      (num >= 0xe000 && num <= 0xfffd) ||
+      (num >= 0x10000 && num <= 0x10ffff)
+    )
   }
 
   function beginWhiteSpace(parser, c) {

--- a/test/invalid-char-entities.js
+++ b/test/invalid-char-entities.js
@@ -1,0 +1,50 @@
+// Character references that resolve to a code point that does not match the
+// XML `Char` production are not well-formed and must fail in strict mode, the
+// same way an out-of-range reference like `&#1114112;` does.
+// https://www.w3.org/TR/REC-xml/#NT-Char
+// https://www.w3.org/TR/REC-xml/#wf-Legalchar
+
+// Each entry is [reference body after `&#`, column of the closing `;`].
+var invalidChars = [
+  ['x1', 8], // restricted control character (SOH)
+  ['xB', 8], // restricted control character (vertical tab)
+  ['x1F', 9], // restricted control character (unit separator)
+  ['xD800', 11], // lone surrogate
+  ['xDFFF', 11], // lone surrogate
+  ['xFFFF', 11], // not a Char
+]
+
+for (var i = invalidChars.length - 1; i >= 0; --i) {
+  var body = invalidChars[i][0]
+  var column = invalidChars[i][1]
+
+  // Strict mode must report the reference as an invalid character entity.
+  require(__dirname).test({
+    xml: '<r>&#' + body + ';</r>',
+    strict: true,
+    expect: [
+      ['opentagstart', { name: 'r', attributes: {} }],
+      ['opentag', { name: 'r', attributes: {}, isSelfClosing: false }],
+      [
+        'error',
+        'Invalid character entity\nLine: 0\nColumn: ' +
+          column +
+          '\nChar: ;',
+      ],
+      ['text', '&#' + body + ';'],
+      ['closetag', 'r'],
+    ],
+  })
+
+  // Non-strict mode is lenient and passes the reference through as text.
+  require(__dirname).test({
+    xml: '<r>&#' + body + ';</r>',
+    strict: false,
+    expect: [
+      ['opentagstart', { name: 'R', attributes: {} }],
+      ['opentag', { name: 'R', attributes: {}, isSelfClosing: false }],
+      ['text', '&#' + body + ';'],
+      ['closetag', 'R'],
+    ],
+  })
+}


### PR DESCRIPTION
XML 1.0 section 4.1 WFC "Legal Character" requires the target of a character reference to match the section 2.2 `Char` production:

```
Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
```

`parseEntity` validates numeric references with isNaN, a digit round-trip, `num < 0`, and `num > 0x10ffff`, but never checks the `Char` production. As a result strict mode silently accepts references that are not well-formed:

* lone surrogates: `&#xD800;`, `&#xDFFF;`
* restricted/illegal controls: `&#x1;`, `&#xB;`, `&#x1F;`, `&#xFFFF;`

The existing strict rejection of out-of-range references like `&#1114112;` (0x110000) and `&#-1;` shows the intent; this completes the same validation set. The fix adds an `isXmlChar(num)` helper implementing the `Char` ranges and adds `|| !isXmlChar(num)` to the existing strictFail condition.

Non-strict (loose) mode is unchanged: invalid references are still passed through as raw text. Valid references such as `&#x9;` and `&#x20;` remain accepted in both modes.

A new test (`test/invalid-char-entities.js`) covers surrogates and restricted controls in both strict (error) and non-strict (passthrough) modes. Verified red before the source change and green after; the full suite passes.

References:
* https://www.w3.org/TR/REC-xml/#NT-Char (section 2.2)
* https://www.w3.org/TR/REC-xml/#wf-Legalchar (section 4.1 WFC)