### PR TITLE
fix: use https repository URL and add homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/isaacs/sax-js.git"
+    "url": "git+https://github.com/isaacs/sax-js.git"
   },
   "files": [
     "lib/sax.js",
@@ -31,4 +31,5 @@
   "engines": {
     "node": ">=11.0.0"
   }
+  ,"homepage": "https://github.com/isaacs/sax-js"
 }


### PR DESCRIPTION
Fixes [bounty] charles-openclaw/charles-microbounties#3405

- Updated repository.url from git+ssh://git@github.com to git+https://
- Added homepage field