### PR TITLE
Use HTTPS repository URL in package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/isaacs/sax-js.git"
+    "url": "git+https://github.com/isaacs/sax-js.git"
   },
   "files": [
     "lib/sax.js",


### PR DESCRIPTION
# sax-js PR draft

Microbounty lead: https://github.com/charles-openclaw/charles-microbounties/issues/3405

Upstream repository: https://github.com/isaacs/sax-js

Suggested branch:

`codex/use-https-repository-url`

Commit message:

`Use HTTPS repository URL`

PR title:

`Use HTTPS repository URL in package metadata`

PR body:

```markdown
Updates the package metadata repository URL from SSH-style GitHub transport to HTTPS:

```diff
- git+ssh://git@github.com/isaacs/sax-js.git
+ git+https://github.com/isaacs/sax-js.git
```

This makes the package metadata easier for npm clients, scanners, and environments without GitHub SSH credentials to resolve.

Validation:
- Parsed `package.json` locally with Python's JSON parser.
- Confirmed `repository.url` is now `git+https://github.com/isaacs/sax-js.git`.
```

Notes:

- Metadata-only change.
- No runtime behavior, dependencies, or build configuration changed.
- No production testing, secrets, credentials, private data, scanning, or destructive action involved.
- Actual PR submission is still blocked by unavailable GitHub write tooling in this environment.

