### PR TITLE
fix: exempt numeric character references from the entity cap (#284)

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1754,8 +1754,15 @@
 
           if (c === ';') {
             var parsedEntity = parseEntity(parser)
+            // Numeric character references (e.g. &#10; or &#xA;) resolve to a
+            // single literal code point and cannot reference other entities,
+            // so they can never drive a billion-laughs expansion. Treat them
+            // like the predefined XML entities: append literally without
+            // counting them toward the entity cap.
+            var isNumericEntity = parser.entity.charAt(0) === '#'
             if (
               parser.opt.unparsedEntities &&
+              !isNumericEntity &&
               !Object.values(sax.XML_ENTITIES).includes(parsedEntity)
             ) {
               if ((parser.entityCount += 1) > parser.opt.maxEntityCount) {

--- a/test/entity-numeric-cap.js
+++ b/test/entity-numeric-cap.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview
+ *   Numeric character references (e.g. &#10;) resolve to a single literal
+ *   code point and cannot reference other entities, so they can never drive a
+ *   billion-laughs style expansion. They must therefore not count toward the
+ *   entity cap enforced when `unparsedEntities` is enabled.
+ *
+ *   Regression test for https://github.com/isaacs/sax-js/issues/284
+ *   ("Entity cap is too conservative"), reported from SVGO where documents
+ *   with many `&#10;` newline references tripped the cap.
+ */
+
+var t = require('tap')
+var sax = require('../lib/sax')
+
+for (var strictMode of [true, false]) {
+  t.test(
+    'numeric character references do not count toward the entity cap',
+    t => {
+      var parser = sax.parser(strictMode, {
+        unparsedEntities: true,
+        maxEntityCount: 2,
+        maxEntityDepth: 1,
+      })
+
+      var text = ''
+      parser.ontext = function (chunk) {
+        text += chunk
+      }
+
+      t.doesNotThrow(() => {
+        // Ten newline references, far more than maxEntityCount.
+        parser
+          .write(
+            '<r>&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;</r>'
+          )
+          .close()
+      }, 'numeric references above the cap must not throw')
+
+      t.equal(text, '\n'.repeat(10), 'all references resolve to newlines')
+      t.equal(parser.entityCount, 0, 'numeric references are not counted')
+      t.end()
+    }
+  )
+
+  t.test('hex numeric references are also excluded from the cap', t => {
+    var parser = sax.parser(strictMode, {
+      unparsedEntities: true,
+      maxEntityCount: 2,
+    })
+
+    var text = ''
+    parser.ontext = function (chunk) {
+      text += chunk
+    }
+
+    t.doesNotThrow(() => {
+      parser.write('<r>&#x41;&#x42;&#x43;&#x44;&#x45;</r>').close()
+    })
+
+    t.equal(text, 'ABCDE', 'hex references resolve correctly')
+    t.equal(parser.entityCount, 0, 'hex references are not counted')
+    t.end()
+  })
+
+  t.test('named entities still count toward the cap', t => {
+    var parser = sax.parser(strictMode, {
+      unparsedEntities: true,
+      maxEntityCount: 3,
+    })
+    parser.ENTITIES = { ...parser.ENTITIES, foo: 'bar' }
+
+    t.throws(
+      () => {
+        parser.write('<r>&foo;&foo;&foo;&foo;</r>')
+      },
+      { message: 'Parsed entity count exceeds max entity count' },
+      'named entities are still capped'
+    )
+    t.end()
+  })
+}


### PR DESCRIPTION
Fixes #284.

## Bug
The entity cap (`maxEntityCount`/`maxEntityDepth`, active with `unparsedEntities: true`) is a billion-laughs defense. Billion-laughs amplification is only possible through **named** entities that recursively reference other entities. A **numeric** character reference (`&#10;`, `&#xA;`) resolves to a single literal code point and cannot reference anything, so it can never amplify — yet numeric refs were counted toward the cap. This breaks legitimate documents (e.g. SVGO-optimized SVGs full of `&#10;` newlines, per the issue).

## Fix
Exempt numeric character references (`parser.entity.charAt(0) === '#'`) from the entity count, appending them literally like the predefined XML entities. Named entities remain capped.

## Verification
- Added `test/entity-numeric-cap.js`: 10 `&#10;` refs with `maxEntityCount: 2` no longer throw and produce 10 newlines with `entityCount === 0`; hex refs resolve; named entities still throw at the cap (control). Runs in strict and non-strict modes.
- New test fails before, passes after. Full suite: **1919/1919 pass** (1905 existing + 14 new).
