### PR TITLE
fix: deduplicate repeated attribute names in xmlns mode

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -893,7 +893,9 @@
     }
 
     if (
-      parser.attribList.indexOf(parser.attribName) !== -1 ||
+      parser.attribList.some(function (nv) {
+        return nv[0] === parser.attribName
+      }) ||
       parser.tag.attributes.hasOwnProperty(parser.attribName)
     ) {
       parser.attribName = parser.attribValue = ''

--- a/test/duplicate-attribute-xmlns.js
+++ b/test/duplicate-attribute-xmlns.js
@@ -1,0 +1,46 @@
+require(__dirname).test({
+  xml: '<a id="hello" id="there"/>',
+  expect: [
+    [
+      'opentagstart',
+      {
+        name: 'a',
+        attributes: {},
+        ns: {},
+      },
+    ],
+    [
+      'attribute',
+      {
+        name: 'id',
+        value: 'hello',
+        uri: '',
+        prefix: '',
+        local: 'id',
+      },
+    ],
+    [
+      'opentag',
+      {
+        name: 'a',
+        uri: '',
+        prefix: '',
+        local: 'a',
+        attributes: {
+          id: {
+            name: 'id',
+            value: 'hello',
+            uri: '',
+            prefix: '',
+            local: 'id',
+          },
+        },
+        ns: {},
+        isSelfClosing: true,
+      },
+    ],
+    ['closetag', 'a'],
+  ],
+  strict: true,
+  opt: { xmlns: true },
+})


### PR DESCRIPTION
In `xmlns` mode a repeated attribute name is not deduplicated: the parser emits two `onattribute` events and the resulting `attributes` object keeps the last value. Without `xmlns` the parser keeps the first value and emits a single event (see `test/duplicate-attribute.js`).

Repro:

```js
var p = require('sax').parser(true, { xmlns: true })
p.onattribute = function (a) { console.log('attribute', a.name, a.value) }
p.onopentag = function (t) { console.log('opentag', t.attributes.id.value) }
p.write('<a id="hello" id="there"/>').close()
// attribute id hello
// attribute id there   <- duplicate event
// opentag there         <- last value wins
```

The dedup guard in `attrib()` is:

```js
parser.attribList.indexOf(parser.attribName) !== -1
```

In `xmlns` mode attributes are deferred into `attribList` as `[name, value]` pairs, so `indexOf(name)` compares a string against arrays and never matches. The `tag.attributes` fallback in the same guard doesn't help either, because attributes aren't committed until `openTag()` runs. The guard now compares the attribute name against the pair names, so the first occurrence is kept and later duplicates are dropped, matching the non-`xmlns` path.

Adds a regression test (fails without the patch, passes with it).
